### PR TITLE
Import types referenced in Javadoc

### DIFF
--- a/javapoet/src/main/java/com/palantir/javapoet/CodeWriter.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/CodeWriter.java
@@ -418,10 +418,7 @@ final class CodeWriter {
             return join(".", className.simpleNames());
         }
 
-        // We'll have to use the fully-qualified name. Mark the type as importable for a future pass.
-        if (!javadoc) {
-            importableType(className);
-        }
+        importableType(className);
 
         return className.canonicalName;
     }

--- a/javapoet/src/test/java/com/palantir/javapoet/CodeWriterTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/CodeWriterTest.java
@@ -30,11 +30,11 @@ public class CodeWriterTest {
         assertThat(out.toString())
                 .isEqualTo(
                         """
-                /**
-                 * A
-                 *
-                 * B
-                 */
-                """);
+                        /**
+                         * A
+                         *
+                         * B
+                         */
+                        """);
     }
 }

--- a/javapoet/src/test/java/com/palantir/javapoet/JavaFileTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/JavaFileTest.java
@@ -304,11 +304,11 @@ public final class JavaFileTest {
         assertThat(source)
                 .isEqualTo(
                         """
-                package com.palantir.tacos;
+                        package com.palantir.tacos;
 
-                class Taco {
-                }
-                """);
+                        class Taco {
+                        }
+                        """);
     }
 
     @Test
@@ -598,11 +598,11 @@ public final class JavaFileTest {
         assertThat(source)
                 .isEqualTo(
                         """
-                                package com.palantir.tacos;
+                        package com.palantir.tacos;
 
-                                class Taco extends com.taco.bell.Taco {
-                                }
-                                """);
+                        class Taco extends com.taco.bell.Taco {
+                        }
+                        """);
     }
 
     @Test
@@ -756,11 +756,11 @@ public final class JavaFileTest {
         assertThat(source)
                 .isEqualTo(
                         """
-                package hello;
+                        package hello;
 
-                class World implements Test {
-                }
-                """);
+                        class World implements Test {
+                        }
+                        """);
     }
 
     @Test

--- a/javapoet/src/test/java/com/palantir/javapoet/MethodSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/MethodSpecTest.java
@@ -212,9 +212,12 @@ public final class MethodSpecTest {
         exec = findFirst(methods, "compareTo");
         method = MethodSpec.overriding(exec, classType, types).build();
         assertThat(method.toString())
-                .isEqualTo("@java.lang.Override\n"
-                        + "public int compareTo(" + ExtendsOthers.class.getCanonicalName() + " arg0) {\n"
-                        + "}\n");
+                .isEqualTo(
+                        """
+                        @java.lang.Override
+                        public int compareTo(com.palantir.javapoet.MethodSpecTest.ExtendsOthers arg0) {
+                        }
+                        """);
         exec = findFirst(methods, "fail");
         method = MethodSpec.overriding(exec, classType, types).build();
         assertThat(method.toString())
@@ -392,10 +395,11 @@ public final class MethodSpecTest {
                 .build();
 
         assertThat(methodSpec.toString())
-                .isEqualTo("""
-                void revisedMethod() {
-                }
-                """);
+                .isEqualTo(
+                        """
+                        void revisedMethod() {
+                        }
+                        """);
     }
 
     @Test
@@ -442,10 +446,10 @@ public final class MethodSpecTest {
         assertThat(methodSpec.toString())
                 .isEqualTo(
                         """
-                void method() {
-                  codeWithNoNewline();
-                }
-                """);
+                        void method() {
+                          codeWithNoNewline();
+                        }
+                        """);
     }
 
     /** Ensures that we don't add a duplicate newline if one is already present. */
@@ -458,10 +462,10 @@ public final class MethodSpecTest {
         assertThat(methodSpec.toString())
                 .isEqualTo(
                         """
-                void method() {
-                  codeWithNoNewline();
-                }
-                """);
+                        void method() {
+                          codeWithNoNewline();
+                        }
+                        """);
     }
 
     @Test

--- a/javapoet/src/test/java/com/palantir/javapoet/TypeSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/TypeSpecTest.java
@@ -923,12 +923,12 @@ public final class TypeSpecTest {
         assertThat(toString(anno))
                 .isEqualTo(
                         """
-                                package com.palantir.tacos;
+                        package com.palantir.tacos;
 
-                                @interface Anno {
-                                  int FOO = 101;
-                                }
-                                """);
+                        @interface Anno {
+                          int FOO = 101;
+                        }
+                        """);
     }
 
     @Test
@@ -1299,7 +1299,7 @@ public final class TypeSpecTest {
     @Test
     public void javadoc() {
         TypeSpec taco = TypeSpec.classBuilder("Taco")
-                .addJavadoc("A hard or soft tortilla, loosely folded and filled with whatever {@link \n")
+                .addJavadoc("A hard or soft tortilla, loosely folded and filled with whatever\n")
                 .addJavadoc("{@link $T random} tex-mex stuff we could find in the pantry\n", Random.class)
                 .addJavadoc(CodeBlock.of("and some {@link $T} cheese.\n", String.class))
                 .addField(FieldSpec.builder(boolean.class, "soft")
@@ -1308,10 +1308,10 @@ public final class TypeSpecTest {
                 .addMethod(MethodSpec.methodBuilder("refold")
                         .addJavadoc(
                                 """
-                                        Folds the back of this taco to reduce sauce leakage.
+                                Folds the back of this taco to reduce sauce leakage.
 
-                                        <p>For {@link $T#KOREAN}, the front may also be folded.
-                                        """,
+                                <p>For {@link $T#KOREAN}, the front may also be folded.
+                                """,
                                 Locale.class)
                         .addParameter(Locale.class, "locale")
                         .build())
@@ -1323,12 +1323,14 @@ public final class TypeSpecTest {
                         """
                         package com.palantir.tacos;
 
+                        import java.lang.String;
                         import java.util.Locale;
+                        import java.util.Random;
 
                         /**
-                         * A hard or soft tortilla, loosely folded and filled with whatever {@link\s
-                         * {@link java.util.Random random} tex-mex stuff we could find in the pantry
-                         * and some {@link java.lang.String} cheese.
+                         * A hard or soft tortilla, loosely folded and filled with whatever
+                         * {@link Random random} tex-mex stuff we could find in the pantry
+                         * and some {@link String} cheese.
                          */
                         class Taco {
                           /**
@@ -1865,10 +1867,12 @@ public final class TypeSpecTest {
     @Test
     public void classToString() {
         TypeSpec type = TypeSpec.classBuilder("Taco").build();
-        assertThat(type.toString()).isEqualTo("""
-                class Taco {
-                }
-                """);
+        assertThat(type.toString())
+                .isEqualTo(
+                        """
+                        class Taco {
+                        }
+                        """);
     }
 
     @Test
@@ -1894,20 +1898,22 @@ public final class TypeSpecTest {
     public void interfaceClassToString() {
         TypeSpec type = TypeSpec.interfaceBuilder("Taco").build();
         assertThat(type.toString())
-                .isEqualTo("""
-                interface Taco {
-                }
-                """);
+                .isEqualTo(
+                        """
+                        interface Taco {
+                        }
+                        """);
     }
 
     @Test
     public void annotationDeclarationToString() {
         TypeSpec type = TypeSpec.annotationBuilder("Taco").build();
         assertThat(type.toString())
-                .isEqualTo("""
-                @interface Taco {
-                }
-                """);
+                .isEqualTo(
+                        """
+                        @interface Taco {
+                        }
+                        """);
     }
 
     private String toString(TypeSpec typeSpec) {


### PR DESCRIPTION
Plus some text block formatting clean up from https://github.com/palantir/javapoet/pull/7.

If, for whatever reason, users can't import types referenced in their Javadocs they should replace `$T` with `$L`, which matches the existing behavior.