### PR TITLE
CodeBlock now checks if too many arguments are provided (#65).

### DIFF
--- a/javapoet/src/main/java/com/palantir/javapoet/CodeBlock.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/CodeBlock.java
@@ -342,9 +342,9 @@ public final class CodeBlock {
 
             // If there is no format specifier, but arguments are provided:
             checkArgument(
-                    hasRelative || hasIndexed || args.length <= 0, 
-                    "unused arguments: expected %s, received %s", 
-                    0, 
+                    hasRelative || hasIndexed || args.length <= 0,
+                    "unused arguments: expected %s, received %s",
+                    0,
                     args.length);
 
             return this;

--- a/javapoet/src/main/java/com/palantir/javapoet/CodeBlock.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/CodeBlock.java
@@ -341,9 +341,12 @@ public final class CodeBlock {
             }
 
             // If there is no format specifier, but arguments are provided:
-            checkArgument(hasRelative || hasIndexed || args.length <= 0, "unused arguments: expected %s, received %s", 0, args.length);
+            checkArgument(
+                    hasRelative || hasIndexed || args.length <= 0, 
+                    "unused arguments: expected %s, received %s", 
+                    0, 
+                    args.length);
 
-            
             return this;
         }
 

--- a/javapoet/src/main/java/com/palantir/javapoet/CodeBlock.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/CodeBlock.java
@@ -339,6 +339,11 @@ public final class CodeBlock {
                 String s = unused.size() == 1 ? "" : "s";
                 checkArgument(unused.isEmpty(), "unused argument%s: %s", s, String.join(", ", unused));
             }
+
+            // If there is no format specifier, but arguments are provided:
+            checkArgument(hasRelative || hasIndexed || args.length <= 0, "unused arguments: expected %s, received %s", 0, args.length);
+
+            
             return this;
         }
 

--- a/javapoet/src/test/java/com/palantir/javapoet/CodeBlockTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/CodeBlockTest.java
@@ -310,6 +310,19 @@ public final class CodeBlockTest {
     }
 
     @Test
+    public void tooManyArguments() {
+        assertThatThrownBy(() -> CodeBlock.of("test", 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("unused arguments: expected %s, received %s", 0, 1);
+        assertThatThrownBy(() -> CodeBlock.of("test", 1, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("unused arguments: expected %s, received %s", 0, 2);
+        assertThatThrownBy(() -> CodeBlock.of("test $L", 2, 3))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("unused arguments: expected %s, received %s", 1, 2);
+    }
+
+    @Test
     public void clear() {
         CodeBlock block =
                 CodeBlock.builder().addStatement("$S", "Test string").clear().build();


### PR DESCRIPTION
## Before this PR
CodeBlock#of does not properly check if too many arguments are provided if there is no format specifier (#65).

## After this PR
Fixes #65.

## Possible downsides?
-

