### PR TITLE
Mention JDK requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ the need to write boilerplate while also keeping a single source of truth for th
 _This repo is forked from the excellent [square/javapoet](https://github.com/square/javapoet) project which is [no longer actively maintained](https://github.com/square/javapoet/discussions/866)._\
 Significant changes:
 
+- Requires JDK 17 or newer\
+  However depending on what JavaPoet methods you use, the generated code can be compiled with older JDK versions as well.
 - Changed package name to `com.palantir.javapoet`
 - Made implementation-specific fields `private` and instead added getter methods
 - Added support for record classes (`TypeSpec#recordBuilder`)


### PR DESCRIPTION
## Before this PR
The class files of this project are compiled with Java 17 as target version, but it is currently not documented.

## After this PR
The minimum JDK version is documented

Not sure if for the generated code a minimum JDK version can be specified as well. It probably mostly depends on what builder methods users are calling. For example if they use `TypeSpec#recordBuilder`, then the generated code can not be compiled with JDK 8.
