### PR TITLE
Fix incomplete `toBuilder` implementations and add tests

### DIFF
--- a/javapoet/src/main/java/com/palantir/javapoet/JavaFile.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/JavaFile.java
@@ -292,6 +292,7 @@ public final class JavaFile {
         builder.fileComment.add(fileComment);
         builder.skipJavaLangImports = skipJavaLangImports;
         builder.indent = indent;
+        builder.staticImports.addAll(staticImports);
         return builder;
     }
 

--- a/javapoet/src/main/java/com/palantir/javapoet/ParameterSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/ParameterSpec.java
@@ -156,6 +156,7 @@ public final class ParameterSpec {
         Builder builder = new Builder(type, name);
         builder.annotations.addAll(annotations);
         builder.modifiers.addAll(modifiers);
+        builder.javadoc.add(javadoc);
         return builder;
     }
 

--- a/javapoet/src/main/java/com/palantir/javapoet/TypeSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/TypeSpec.java
@@ -88,14 +88,11 @@ public final class TypeSpec {
         this.recordConstructor = builder.recordConstructor;
 
         nestedTypesSimpleNames = new HashSet<>();
-        List<Element> originatingElementsMutable = new ArrayList<>();
-        originatingElementsMutable.addAll(builder.originatingElements);
         for (TypeSpec typeSpec : builder.typeSpecs) {
             nestedTypesSimpleNames.add(typeSpec.name);
-            originatingElementsMutable.addAll(typeSpec.originatingElements);
         }
 
-        this.originatingElements = Util.immutableList(originatingElementsMutable);
+        this.originatingElements = Util.immutableList(builder.originatingElements);
     }
 
     /**
@@ -190,7 +187,15 @@ public final class TypeSpec {
     }
 
     public List<Element> originatingElements() {
-        return originatingElements;
+        if (typeSpecs.isEmpty()) {
+            return originatingElements;
+        }
+
+        List<Element> allOriginatingElements = new ArrayList<>(originatingElements);
+        for (TypeSpec typeSpec : typeSpecs) {
+            allOriginatingElements.addAll(typeSpec.originatingElements());
+        }
+        return allOriginatingElements;
     }
 
     public Set<String> alwaysQualifiedNames() {

--- a/javapoet/src/main/java/com/palantir/javapoet/TypeSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/TypeSpec.java
@@ -260,6 +260,7 @@ public final class TypeSpec {
         builder.typeSpecs.addAll(typeSpecs);
         builder.initializerBlock.add(initializerBlock);
         builder.staticBlock.add(staticBlock);
+        builder.recordConstructor = recordConstructor;
         builder.originatingElements.addAll(originatingElements);
         builder.alwaysQualifiedNames.addAll(alwaysQualifiedNames);
         return builder;

--- a/javapoet/src/test/java/com/palantir/javapoet/FieldSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/FieldSpecTest.java
@@ -19,28 +19,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import javax.lang.model.element.Modifier;
-import org.junit.After;
 import org.junit.Test;
 
 public class FieldSpecTest {
     /**
-     * Field spec created by a test method; used by {@link #checkToBuilderRoundtrip()}.
-     *
-     * <p>{@code null} if a test method does not create a (valid) field spec, or if no round-trip check
-     * should be performed on it.
-     */
-    private FieldSpec fieldSpec = null;
-
-    /**
      * Performs round-trip check that {@code fieldSpec.toBuilder().build()} is identical to the
      * original {@code fieldSpec}.
      */
-    @After
-    public void checkToBuilderRoundtrip() {
-        if (fieldSpec == null) {
-            return;
-        }
-
+    private static void checkToBuilderRoundtrip(FieldSpec fieldSpec) {
         String originalToString = fieldSpec.toString();
         int originalHashCode = fieldSpec.hashCode();
 
@@ -65,8 +51,7 @@ public class FieldSpecTest {
         assertThat(a.hashCode()).isEqualTo(b.hashCode());
         assertThat(a.toString()).isEqualTo(b.toString());
 
-        // Perform round-trip check in @After
-        fieldSpec = a;
+        checkToBuilderRoundtrip(a);
     }
 
     @Test

--- a/javapoet/src/test/java/com/palantir/javapoet/FieldSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/FieldSpecTest.java
@@ -19,9 +19,37 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import javax.lang.model.element.Modifier;
+import org.junit.After;
 import org.junit.Test;
 
 public class FieldSpecTest {
+    /**
+     * Field spec created by a test method; used by {@link #checkToBuilderRoundtrip()}.
+     *
+     * <p>{@code null} if a test method does not create a (valid) field spec, or if no round-trip check
+     * should be performed on it.
+     */
+    private FieldSpec fieldSpec = null;
+
+    /**
+     * Performs round-trip check that {@code fieldSpec.toBuilder().build()} is identical to the
+     * original {@code fieldSpec}.
+     */
+    @After
+    public void checkToBuilderRoundtrip() {
+        if (fieldSpec == null) {
+            return;
+        }
+
+        String originalToString = fieldSpec.toString();
+        int originalHashCode = fieldSpec.hashCode();
+
+        FieldSpec roundtripFieldSpec = fieldSpec.toBuilder().build();
+        assertThat(roundtripFieldSpec.toString()).isEqualTo(originalToString);
+        assertThat(roundtripFieldSpec.hashCode()).isEqualTo(originalHashCode);
+        assertThat(roundtripFieldSpec).isEqualTo(fieldSpec);
+    }
+
     @Test
     public void equalsAndHashCode() {
         FieldSpec a = FieldSpec.builder(int.class, "foo").build();
@@ -36,6 +64,9 @@ public class FieldSpecTest {
         assertThat(a.equals(b)).isTrue();
         assertThat(a.hashCode()).isEqualTo(b.hashCode());
         assertThat(a.toString()).isEqualTo(b.toString());
+
+        // Perform round-trip check in @After
+        fieldSpec = a;
     }
 
     @Test

--- a/javapoet/src/test/java/com/palantir/javapoet/JavaFileTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/JavaFileTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
-import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,23 +46,10 @@ public final class JavaFileTest {
     }
 
     /**
-     * Java file created by a test method; used by {@link #checkToBuilderRoundtrip()}.
-     *
-     * <p>{@code null} if a test method does not create a (valid) {@code JavaFile}, or if no round-trip check
-     * should be performed on it.
-     */
-    private JavaFile javaFile = null;
-
-    /**
      * Performs round-trip check that {@code javaFile.toBuilder().build()} is identical to the
      * original {@code javaFile}.
      */
-    @After
-    public void checkToBuilderRoundtrip() {
-        if (javaFile == null) {
-            return;
-        }
-
+    private static void checkToBuilderRoundtrip(JavaFile javaFile) {
         String originalToString = javaFile.toString();
         int originalHashCode = javaFile.hashCode();
 
@@ -90,7 +76,7 @@ public final class JavaFileTest {
                 .addStatement("return result.isEmpty() ? $T.emptyList() : result", Collections.class)
                 .build();
         TypeSpec hello = TypeSpec.classBuilder("HelloWorld").addMethod(beyond).build();
-        javaFile = JavaFile.builder("com.example.helloworld", hello)
+        JavaFile javaFile = JavaFile.builder("com.example.helloworld", hello)
                 .addStaticImport(hoverboard, "createNimbus")
                 .addStaticImport(namedBoards, "*")
                 .addStaticImport(Collections.class, "*")
@@ -119,12 +105,13 @@ public final class JavaFileTest {
                           }
                         }
                         """);
+        checkToBuilderRoundtrip(javaFile);
     }
 
     @Test
     public void importStaticForCrazyFormatsWorks() {
         MethodSpec method = MethodSpec.methodBuilder("method").build();
-        javaFile = JavaFile.builder(
+        JavaFile javaFile = JavaFile.builder(
                         "com.palantir.tacos",
                         TypeSpec.classBuilder("Taco")
                                 .addStaticBlock(CodeBlock.builder()
@@ -146,11 +133,12 @@ public final class JavaFileTest {
                 .build();
 
         assertThatCode(javaFile::toString).doesNotThrowAnyException();
+        checkToBuilderRoundtrip(javaFile);
     }
 
     @Test
     public void importStaticMixed() {
-        javaFile = JavaFile.builder(
+        JavaFile javaFile = JavaFile.builder(
                         "com.palantir.tacos",
                         TypeSpec.classBuilder("Taco")
                                 .addStaticBlock(CodeBlock.builder()
@@ -190,12 +178,13 @@ public final class JavaFileTest {
                           }
                         }
                         """);
+        checkToBuilderRoundtrip(javaFile);
     }
 
     @Ignore("addStaticImport doesn't support members with $L")
     @Test
     public void importStaticDynamic() {
-        javaFile = JavaFile.builder(
+        JavaFile javaFile = JavaFile.builder(
                         "com.palantir.tacos",
                         TypeSpec.classBuilder("Taco")
                                 .addMethod(MethodSpec.methodBuilder("main")
@@ -217,11 +206,12 @@ public final class JavaFileTest {
                           }
                         }
                         """);
+        checkToBuilderRoundtrip(javaFile);
     }
 
     @Test
     public void importStaticNone() {
-        javaFile = JavaFile.builder("readme", importStaticTypeSpec("Util"))
+        JavaFile javaFile = JavaFile.builder("readme", importStaticTypeSpec("Util"))
                 .build();
         assertThat(javaFile.toString())
                 .isEqualTo(
@@ -238,11 +228,12 @@ public final class JavaFileTest {
                           }
                         }
                         """);
+        checkToBuilderRoundtrip(javaFile);
     }
 
     @Test
     public void importStaticOnce() {
-        javaFile = JavaFile.builder("readme", importStaticTypeSpec("Util"))
+        JavaFile javaFile = JavaFile.builder("readme", importStaticTypeSpec("Util"))
                 .addStaticImport(TimeUnit.SECONDS)
                 .build();
         assertThat(javaFile.toString())
@@ -262,11 +253,12 @@ public final class JavaFileTest {
                           }
                         }
                         """);
+        checkToBuilderRoundtrip(javaFile);
     }
 
     @Test
     public void importStaticTwice() {
-        javaFile = JavaFile.builder("readme", importStaticTypeSpec("Util"))
+        JavaFile javaFile = JavaFile.builder("readme", importStaticTypeSpec("Util"))
                 .addStaticImport(TimeUnit.SECONDS)
                 .addStaticImport(TimeUnit.MINUTES)
                 .build();
@@ -287,11 +279,12 @@ public final class JavaFileTest {
                           }
                         }
                         """);
+        checkToBuilderRoundtrip(javaFile);
     }
 
     @Test
     public void importStaticUsingWildcards() {
-        javaFile = JavaFile.builder("readme", importStaticTypeSpec("Util"))
+        JavaFile javaFile = JavaFile.builder("readme", importStaticTypeSpec("Util"))
                 .addStaticImport(TimeUnit.class, "*")
                 .addStaticImport(System.class, "*")
                 .build();
@@ -310,6 +303,7 @@ public final class JavaFileTest {
                           }
                         }
                         """);
+        checkToBuilderRoundtrip(javaFile);
     }
 
     private TypeSpec importStaticTypeSpec(String name) {
@@ -325,7 +319,7 @@ public final class JavaFileTest {
 
     @Test
     public void noImports() {
-        javaFile = JavaFile.builder("com.palantir.tacos", TypeSpec.classBuilder("Taco").build())
+        JavaFile javaFile = JavaFile.builder("com.palantir.tacos", TypeSpec.classBuilder("Taco").build())
                 .build();
         assertThat(javaFile.toString())
                 .isEqualTo(
@@ -335,6 +329,7 @@ public final class JavaFileTest {
                         class Taco {
                         }
                         """);
+        checkToBuilderRoundtrip(javaFile);
     }
 
     @Test
@@ -937,7 +932,7 @@ public final class JavaFileTest {
 
     @Test
     public void topOfFileComment() {
-        javaFile = JavaFile.builder(
+        JavaFile javaFile = JavaFile.builder(
                         "com.palantir.tacos", TypeSpec.classBuilder("Taco").build())
                 .addFileComment("Generated $L by JavaPoet. DO NOT EDIT!", "2015-01-13")
                 .build();
@@ -950,11 +945,12 @@ public final class JavaFileTest {
                         class Taco {
                         }
                         """);
+        checkToBuilderRoundtrip(javaFile);
     }
 
     @Test
     public void emptyLinesInTopOfFileComment() {
-        javaFile = JavaFile.builder(
+        JavaFile javaFile = JavaFile.builder(
                         "com.palantir.tacos", TypeSpec.classBuilder("Taco").build())
                 .addFileComment("\nGENERATED FILE:\n\nDO NOT EDIT!\n")
                 .build();
@@ -971,6 +967,7 @@ public final class JavaFileTest {
                         class Taco {
                         }
                         """);
+        checkToBuilderRoundtrip(javaFile);
     }
 
     @Test
@@ -1041,7 +1038,7 @@ public final class JavaFileTest {
 
     @Test
     public void alwaysQualifySupersedesJavaLangImports() {
-        javaFile = JavaFile.builder(
+        JavaFile javaFile = JavaFile.builder(
                         "com.palantir.tacos",
                         TypeSpec.classBuilder("Taco")
                                 .addField(Thread.class, "thread")
@@ -1058,6 +1055,7 @@ public final class JavaFileTest {
                           java.lang.Thread thread;
                         }
                         """);
+        checkToBuilderRoundtrip(javaFile);
     }
 
     @Test

--- a/javapoet/src/test/java/com/palantir/javapoet/ParameterSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/ParameterSpecTest.java
@@ -30,7 +30,6 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.util.Elements;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,23 +51,10 @@ public class ParameterSpecTest {
     }
 
     /**
-     * Parameter spec created by a test method; used by {@link #checkToBuilderRoundtrip()}.
-     *
-     * <p>{@code null} if a test method does not create a (valid) parameter spec, or if no round-trip check
-     * should be performed on it.
-     */
-    private ParameterSpec parameterSpec = null;
-
-    /**
      * Performs round-trip check that {@code parameterSpec.toBuilder().build()} is identical to the
      * original {@code parameterSpec}.
      */
-    @After
-    public void checkToBuilderRoundtrip() {
-        if (parameterSpec == null) {
-            return;
-        }
-
+    private static void checkToBuilderRoundtrip(ParameterSpec parameterSpec) {
         String originalMethodString = toMethodString(parameterSpec);
         String originalToString = parameterSpec.toString();
         int originalHashCode = parameterSpec.hashCode();
@@ -80,7 +66,7 @@ public class ParameterSpecTest {
         assertThat(roundtripParameterSpec).isEqualTo(parameterSpec);
     }
 
-    private String toMethodString(ParameterSpec parameterSpec) {
+    private static String toMethodString(ParameterSpec parameterSpec) {
         // Add parameter to MethodSpec because at least parameter Javadoc is only emitted when part of a method
         return MethodSpec.methodBuilder("test").addParameter(parameterSpec).build().toString();
     }
@@ -98,20 +84,21 @@ public class ParameterSpecTest {
         assertThat(a.hashCode()).isEqualTo(b.hashCode());
         assertThat(a.toString()).isEqualTo(b.toString());
 
-        // Perform round-trip check in @After
-        parameterSpec = a;
+        checkToBuilderRoundtrip(a);
     }
 
     @Test
     public void receiverParameterInstanceMethod() {
-        parameterSpec = ParameterSpec.builder(int.class, "this").build();
+        ParameterSpec parameterSpec = ParameterSpec.builder(int.class, "this").build();
         assertThat(parameterSpec.name()).isEqualTo("this");
+        checkToBuilderRoundtrip(parameterSpec);
     }
 
     @Test
     public void receiverParameterNestedClass() {
-        parameterSpec = ParameterSpec.builder(int.class, "Foo.this").build();
+        ParameterSpec parameterSpec = ParameterSpec.builder(int.class, "Foo.this").build();
         assertThat(parameterSpec.name()).isEqualTo("Foo.this");
+        checkToBuilderRoundtrip(parameterSpec);
     }
 
     @Test
@@ -154,8 +141,9 @@ public class ParameterSpecTest {
         ExecutableElement element = findFirst(methods, "foo");
         VariableElement parameterElement = element.getParameters().get(0);
 
-        parameterSpec = ParameterSpec.get(parameterElement);
+        ParameterSpec parameterSpec = ParameterSpec.get(parameterElement);
         assertThat(parameterSpec.toString()).isEqualTo("final java.lang.String bar");
+        checkToBuilderRoundtrip(parameterSpec);
     }
 
     @Test
@@ -171,7 +159,7 @@ public class ParameterSpecTest {
 
     @Test
     public void parameterJavadoc() {
-        parameterSpec = ParameterSpec.builder(int.class, "i").addJavadoc("My param").build();
+        ParameterSpec parameterSpec = ParameterSpec.builder(int.class, "i").addJavadoc("My param").build();
         assertThat(toMethodString(parameterSpec))
                 .isEqualTo(
                         """
@@ -181,5 +169,6 @@ public class ParameterSpecTest {
                         void test(int i) {
                         }
                         """);
+        checkToBuilderRoundtrip(parameterSpec);
     }
 }

--- a/javapoet/src/test/java/com/palantir/javapoet/ParameterSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/ParameterSpecTest.java
@@ -69,13 +69,20 @@ public class ParameterSpecTest {
             return;
         }
 
+        String originalMethodString = toMethodString(parameterSpec);
         String originalToString = parameterSpec.toString();
         int originalHashCode = parameterSpec.hashCode();
 
         ParameterSpec roundtripParameterSpec = parameterSpec.toBuilder().build();
+        assertThat(toMethodString(roundtripParameterSpec)).isEqualTo(originalMethodString);
         assertThat(roundtripParameterSpec.toString()).isEqualTo(originalToString);
         assertThat(roundtripParameterSpec.hashCode()).isEqualTo(originalHashCode);
         assertThat(roundtripParameterSpec).isEqualTo(parameterSpec);
+    }
+
+    private String toMethodString(ParameterSpec parameterSpec) {
+        // Add parameter to MethodSpec because at least parameter Javadoc is only emitted when part of a method
+        return MethodSpec.methodBuilder("test").addParameter(parameterSpec).build().toString();
     }
 
     @Test
@@ -160,5 +167,19 @@ public class ParameterSpecTest {
         assertThatThrownBy(() -> ParameterSpec.builder(int.class, "foo").addModifiers(modifiers))
                 .isInstanceOf(Exception.class)
                 .hasMessage("unexpected parameter modifier: public");
+    }
+
+    @Test
+    public void parameterJavadoc() {
+        parameterSpec = ParameterSpec.builder(int.class, "i").addJavadoc("My param").build();
+        assertThat(toMethodString(parameterSpec))
+                .isEqualTo(
+                        """
+                        /**
+                         * @param i My param
+                         */
+                        void test(int i) {
+                        }
+                        """);
     }
 }

--- a/javapoet/src/test/java/com/palantir/javapoet/TypeSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/TypeSpecTest.java
@@ -1478,13 +1478,20 @@ public final class TypeSpecTest {
     public void originatingElementsIncludesThoseOfNestedTypes() {
         Element outerElement = Mockito.mock(Element.class);
         Element innerElement = Mockito.mock(Element.class);
+        Element innerInnerElement = Mockito.mock(Element.class);
+
         TypeSpec outer = TypeSpec.classBuilder("Outer")
                 .addOriginatingElement(outerElement)
                 .addType(TypeSpec.classBuilder("Inner")
                         .addOriginatingElement(innerElement)
+                        .addType(TypeSpec.classBuilder("InnerInner")
+                                .addOriginatingElement(innerInnerElement)
+                                .build())
                         .build())
                 .build();
-        assertThat(outer.originatingElements()).containsExactly(outerElement, innerElement);
+        assertThat(outer.originatingElements()).containsExactly(outerElement, innerElement, innerInnerElement);
+        assertThat(outer.toBuilder().build().originatingElements()).containsExactly(
+                outerElement, innerElement, innerInnerElement);
         checkToBuilderRoundtrip(outer);
     }
 


### PR DESCRIPTION
## Description
Fixes #341

- For JavaFile it was not copying `staticImports`
- For TypeSpec it was not copying `recordConstructor`
- For TypeSpec it was accumulating additional elements in `originatingElements` from nested types for every `toBuilder().build()` cycle
- For ParameterSpec it was not copying `javadoc`