### PR TITLE
Perform additional validation & fail earlier for incorrect arguments

### DIFF
--- a/javapoet/src/main/java/com/palantir/javapoet/AnnotationSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/AnnotationSpec.java
@@ -127,6 +127,7 @@ public final class AnnotationSpec {
     }
 
     public static AnnotationSpec get(Annotation annotation, boolean includeDefaultValues) {
+        checkNotNull(annotation, "annotation == null");
         Builder builder = builder(annotation.annotationType());
         try {
             Method[] methods = annotation.annotationType().getDeclaredMethods();
@@ -157,6 +158,7 @@ public final class AnnotationSpec {
     }
 
     public static AnnotationSpec get(AnnotationMirror annotation) {
+        checkNotNull(annotation, "annotation == null");
         TypeElement element = (TypeElement) annotation.getAnnotationType().asElement();
         AnnotationSpec.Builder builder = AnnotationSpec.builder(ClassName.get(element));
         Visitor visitor = new Visitor(builder);
@@ -230,6 +232,8 @@ public final class AnnotationSpec {
         }
 
         public Builder addMember(String name, CodeBlock codeBlock) {
+            checkNotNull(name, "name == null");
+            checkNotNull(codeBlock, "codeBlock == null");
             List<CodeBlock> values = members.computeIfAbsent(name, _k -> new ArrayList<>());
             values.add(codeBlock);
             return this;

--- a/javapoet/src/main/java/com/palantir/javapoet/ArrayTypeName.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/ArrayTypeName.java
@@ -36,7 +36,7 @@ public final class ArrayTypeName extends TypeName {
 
     private ArrayTypeName(TypeName componentType, List<AnnotationSpec> annotations) {
         super(annotations);
-        this.componentType = checkNotNull(componentType, "rawType == null");
+        this.componentType = checkNotNull(componentType, "componentType == null");
     }
 
     public TypeName componentType() {
@@ -100,6 +100,7 @@ public final class ArrayTypeName extends TypeName {
     }
 
     static ArrayTypeName get(ArrayType mirror, Map<TypeParameterElement, TypeVariableName> typeVariables) {
+        checkNotNull(mirror, "mirror == null");
         return new ArrayTypeName(get(mirror.getComponentType(), typeVariables));
     }
 
@@ -109,6 +110,6 @@ public final class ArrayTypeName extends TypeName {
     }
 
     static ArrayTypeName get(GenericArrayType type, Map<Type, TypeVariableName> map) {
-        return ArrayTypeName.of(get(type.getGenericComponentType(), map));
+        return of(get(type.getGenericComponentType(), map));
     }
 }

--- a/javapoet/src/main/java/com/palantir/javapoet/ClassName.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/ClassName.java
@@ -17,6 +17,7 @@ package com.palantir.javapoet;
 
 import static com.palantir.javapoet.Util.checkArgument;
 import static com.palantir.javapoet.Util.checkNotNull;
+import static com.palantir.javapoet.Util.checkState;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -68,6 +69,8 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
             String packageName, ClassName enclosingClassName, String simpleName, List<AnnotationSpec> annotations) {
         super(annotations);
         this.packageName = checkNotNull(packageName, "packageName == null");
+        checkState(enclosingClassName == null || enclosingClassName.packageName.equals(packageName),
+                "enclosing class is in wrong package");
         this.enclosingClassName = enclosingClassName;
         this.simpleName = checkNotNull(simpleName, "simpleName == null");
         this.canonicalName = enclosingClassName != null

--- a/javapoet/src/main/java/com/palantir/javapoet/ClassName.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/ClassName.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
@@ -68,9 +67,9 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
     private ClassName(
             String packageName, ClassName enclosingClassName, String simpleName, List<AnnotationSpec> annotations) {
         super(annotations);
-        this.packageName = Objects.requireNonNull(packageName, "packageName == null");
+        this.packageName = checkNotNull(packageName, "packageName == null");
         this.enclosingClassName = enclosingClassName;
-        this.simpleName = simpleName;
+        this.simpleName = checkNotNull(simpleName, "simpleName == null");
         this.canonicalName = enclosingClassName != null
                 ? (enclosingClassName.canonicalName + '.' + simpleName)
                 : (packageName.isEmpty() ? simpleName : packageName + '.' + simpleName);
@@ -168,7 +167,7 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
     /**
      * Returns the full class name of this class.
      * Like {@code "java.util.Map.Entry"} for {@link Map.Entry}.
-     * */
+     */
     public String canonicalName() {
         return canonicalName;
     }
@@ -250,6 +249,7 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
      * instances without such restrictions.
      */
     public static ClassName bestGuess(String classNameString) {
+        checkNotNull(classNameString, "classNameString == null");
         // Add the package name, like "java.util.concurrent", or "" for no package.
         int p = 0;
         while (p < classNameString.length() && Character.isLowerCase(classNameString.codePointAt(p))) {

--- a/javapoet/src/main/java/com/palantir/javapoet/CodeBlock.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/CodeBlock.java
@@ -16,6 +16,7 @@
 package com.palantir.javapoet;
 
 import static com.palantir.javapoet.Util.checkArgument;
+import static com.palantir.javapoet.Util.checkNotNull;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -129,6 +130,8 @@ public final class CodeBlock {
      * would produce {@code String s, Object o, int i}.
      */
     public static CodeBlock join(Iterable<CodeBlock> codeBlocks, String separator) {
+        checkNotNull(codeBlocks, "codeBlocks == null");
+        checkNotNull(separator, "separator == null");
         return StreamSupport.stream(codeBlocks.spliterator(), false).collect(joining(separator));
     }
 
@@ -138,6 +141,7 @@ public final class CodeBlock {
      * {@code int i} using {@code ", "} would produce {@code String s, Object o, int i}.
      */
     public static Collector<CodeBlock, ?, CodeBlock> joining(String separator) {
+        checkNotNull(separator, "separator == null");
         return Collector.of(
                 () -> new CodeBlockJoiner(separator, builder()),
                 CodeBlockJoiner::add,
@@ -151,6 +155,9 @@ public final class CodeBlock {
      * {@code int i} using {@code ", "} would produce {@code String s, Object o, int i}.
      */
     public static Collector<CodeBlock, ?, CodeBlock> joining(String separator, String prefix, String suffix) {
+        checkNotNull(separator, "separator == null");
+        checkNotNull(prefix, "prefix == null");
+        checkNotNull(suffix, "suffix == null");
         Builder builder = builder().add("$N", prefix);
         return Collector.of(
                 () -> new CodeBlockJoiner(separator, builder), CodeBlockJoiner::add, CodeBlockJoiner::merge, joiner -> {
@@ -192,6 +199,8 @@ public final class CodeBlock {
          * value {@code java.lang.Integer.class} in the argument map.
          */
         public Builder addNamed(String format, Map<String, ?> arguments) {
+            checkNotNull(format, "format == null");
+            checkNotNull(arguments, "arguments == null");
             int p = 0;
 
             for (String argument : arguments.keySet()) {
@@ -243,6 +252,7 @@ public final class CodeBlock {
         }
 
         public Builder add(CodeBlock codeBlock) {
+            checkNotNull(codeBlock, "codeBlock == null");
             formatParts.addAll(codeBlock.formatParts);
             args.addAll(codeBlock.args);
             return this;
@@ -260,6 +270,8 @@ public final class CodeBlock {
          * error.
          */
         public Builder add(String format, Object... args) {
+            checkNotNull(format, "format == null");
+            checkNotNull(args, "args == null");
             boolean hasRelative = false;
             boolean hasIndexed = false;
 
@@ -421,6 +433,7 @@ public final class CodeBlock {
          * Shouldn't contain braces or newline characters.
          */
         public Builder beginControlFlow(String controlFlow, Object... args) {
+            checkNotNull(controlFlow, "controlFlow == null"); // otherwise string concat turns this into non-null
             add(controlFlow + " {\n", args);
             indent();
             return this;
@@ -431,6 +444,7 @@ public final class CodeBlock {
          *     Shouldn't contain braces or newline characters.
          */
         public Builder nextControlFlow(String controlFlow, Object... args) {
+            checkNotNull(controlFlow, "controlFlow == null"); // otherwise string concat turns this into non-null
             unindent();
             add("} " + controlFlow + " {\n", args);
             indent();
@@ -448,6 +462,7 @@ public final class CodeBlock {
          *     "while(foo == 20)". Only used for "do/while" control flows.
          */
         public Builder endControlFlow(String controlFlow, Object... args) {
+            checkNotNull(controlFlow, "controlFlow == null"); // otherwise string concat turns this into non-null
             unindent();
             add("} " + controlFlow + ";\n", args);
             return this;
@@ -461,6 +476,7 @@ public final class CodeBlock {
         }
 
         public Builder addStatement(CodeBlock codeBlock) {
+            checkNotNull(codeBlock, "codeBlock == null");
             return addStatement("$L", codeBlock);
         }
 

--- a/javapoet/src/main/java/com/palantir/javapoet/CodeWriter.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/CodeWriter.java
@@ -16,6 +16,7 @@
 package com.palantir.javapoet;
 
 import static com.palantir.javapoet.Util.checkArgument;
+import static com.palantir.javapoet.Util.checkNoNullElement;
 import static com.palantir.javapoet.Util.checkNotNull;
 import static com.palantir.javapoet.Util.checkState;
 import static com.palantir.javapoet.Util.stringLiteralWithDoubleQuotes;
@@ -133,6 +134,7 @@ final class CodeWriter {
     }
 
     public CodeWriter pushType(TypeSpec type) {
+        checkNotNull(type, "type == null");
         this.typeSpecStack.add(type);
         return this;
     }
@@ -143,6 +145,7 @@ final class CodeWriter {
     }
 
     public void emitComment(CodeBlock codeBlock) throws IOException {
+        checkNotNull(codeBlock, "codeBlock == null");
         trailingNewline = true; // Force the '//' prefix for the comment.
         comment = true;
         try {
@@ -154,6 +157,7 @@ final class CodeWriter {
     }
 
     public void emitJavadoc(CodeBlock javadocCodeBlock) throws IOException {
+        checkNotNull(javadocCodeBlock, "javadocCodeBlock == null");
         if (javadocCodeBlock.isEmpty()) {
             return;
         }
@@ -169,6 +173,7 @@ final class CodeWriter {
     }
 
     public void emitAnnotations(List<AnnotationSpec> annotations, boolean inline) throws IOException {
+        checkNoNullElement(annotations, "annotations");
         for (AnnotationSpec annotationSpec : annotations) {
             annotationSpec.emit(this, inline);
             emit(inline ? " " : "\n");
@@ -180,6 +185,8 @@ final class CodeWriter {
      * be emitted.
      */
     public void emitModifiers(Set<Modifier> modifiers, Set<Modifier> implicitModifiers) throws IOException {
+        checkNoNullElement(modifiers, "modifiers");
+        checkNoNullElement(implicitModifiers, "implicitModifiers");
         if (modifiers.isEmpty()) {
             return;
         }
@@ -201,6 +208,7 @@ final class CodeWriter {
      * everywhere else bounds are omitted.
      */
     public void emitTypeVariables(List<TypeVariableName> typeVariables) throws IOException {
+        checkNoNullElement(typeVariables, "typeVariables");
         if (typeVariables.isEmpty()) {
             return;
         }
@@ -258,6 +266,7 @@ final class CodeWriter {
     }
 
     public void popTypeVariables(List<TypeVariableName> typeVariables) {
+        checkNoNullElement(typeVariables, "typeVariables");
         typeVariables.forEach(typeVariable -> currentTypeVariables.remove(typeVariable.name()));
     }
 
@@ -274,6 +283,7 @@ final class CodeWriter {
     }
 
     public CodeWriter emit(CodeBlock codeBlock, boolean ensureTrailingNewline) throws IOException {
+        checkNotNull(codeBlock, "codeBlock == null");
         int a = 0;
         ClassName deferredTypeName = null; // used by "import static" logic
         ListIterator<String> partIterator = codeBlock.formatParts().listIterator();
@@ -518,6 +528,7 @@ final class CodeWriter {
      * unnecessary trailing whitespace.
      */
     CodeWriter emitAndIndent(String s) throws IOException {
+        checkNotNull(s, "s == null");
         boolean first = true;
         for (String line : LINE_BREAKING_PATTERN.split(s, -1)) {
             // Emit a newline character. Make sure blank lines in Javadoc & comments look good.

--- a/javapoet/src/main/java/com/palantir/javapoet/FieldSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/FieldSpec.java
@@ -16,6 +16,7 @@
 package com.palantir.javapoet;
 
 import static com.palantir.javapoet.Util.checkArgument;
+import static com.palantir.javapoet.Util.checkNoNullElement;
 import static com.palantir.javapoet.Util.checkNotNull;
 import static com.palantir.javapoet.Util.checkState;
 
@@ -116,6 +117,7 @@ public final class FieldSpec {
 
     public static Builder builder(TypeName type, String name, Modifier... modifiers) {
         checkNotNull(type, "type == null");
+        checkNotNull(name, "name == null");
         checkArgument(SourceVersion.isName(name), "not a valid name: %s", name);
         return new Builder(type, name).addModifiers(modifiers);
     }
@@ -159,21 +161,21 @@ public final class FieldSpec {
         }
 
         public Builder addAnnotations(Iterable<AnnotationSpec> annotationSpecs) {
-            checkArgument(annotationSpecs != null, "annotationSpecs == null");
+            checkNotNull(annotationSpecs, "annotationSpecs == null");
             for (AnnotationSpec annotationSpec : annotationSpecs) {
-                this.annotations.add(annotationSpec);
+                addAnnotation(annotationSpec);
             }
             return this;
         }
 
         public Builder addAnnotation(AnnotationSpec annotationSpec) {
+            checkNotNull(annotationSpec, "annotationSpec == null");
             this.annotations.add(annotationSpec);
             return this;
         }
 
         public Builder addAnnotation(ClassName annotation) {
-            this.annotations.add(AnnotationSpec.builder(annotation).build());
-            return this;
+            return addAnnotation(AnnotationSpec.builder(annotation).build());
         }
 
         public Builder addAnnotation(Class<?> annotation) {
@@ -181,7 +183,7 @@ public final class FieldSpec {
         }
 
         public Builder addModifiers(Modifier... modifiers) {
-            Collections.addAll(this.modifiers, modifiers);
+            Collections.addAll(this.modifiers, checkNoNullElement(modifiers, "modifiers"));
             return this;
         }
 

--- a/javapoet/src/main/java/com/palantir/javapoet/FieldSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/FieldSpec.java
@@ -16,9 +16,9 @@
 package com.palantir.javapoet;
 
 import static com.palantir.javapoet.Util.checkArgument;
-import static com.palantir.javapoet.Util.checkNoNullElement;
 import static com.palantir.javapoet.Util.checkNotNull;
 import static com.palantir.javapoet.Util.checkState;
+import static com.palantir.javapoet.Util.nonNullList;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -183,7 +183,15 @@ public final class FieldSpec {
         }
 
         public Builder addModifiers(Modifier... modifiers) {
-            Collections.addAll(this.modifiers, checkNoNullElement(modifiers, "modifiers"));
+            return addModifiers(nonNullList(modifiers, "modifiers"));
+        }
+
+        public Builder addModifiers(Iterable<Modifier> modifiers) {
+            checkNotNull(modifiers, "modifiers == null");
+            for (Modifier modifier : modifiers) {
+                checkNotNull(modifier, "modifiers contain null");
+                this.modifiers.add(modifier);
+            }
             return this;
         }
 

--- a/javapoet/src/main/java/com/palantir/javapoet/JavaFile.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/JavaFile.java
@@ -16,6 +16,7 @@
 package com.palantir.javapoet;
 
 import static com.palantir.javapoet.Util.checkArgument;
+import static com.palantir.javapoet.Util.checkNoNullElement;
 import static com.palantir.javapoet.Util.checkNotNull;
 
 import java.io.ByteArrayInputStream;
@@ -30,7 +31,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -99,6 +99,7 @@ public final class JavaFile {
     }
 
     public void writeTo(Appendable out) throws IOException {
+        checkNotNull(out, "out == null");
         // First pass: emit the entire class, just to collect the types we'll need to import.
         CodeWriter importsCollector = new CodeWriter(NULL_APPENDABLE, indent, staticImports, alwaysQualify);
         emit(importsCollector);
@@ -129,6 +130,7 @@ public final class JavaFile {
 
     /** Writes this to {@code filer}. */
     public void writeTo(Filer filer) throws IOException {
+        checkNotNull(filer, "filer == null");
         String fileName = packageName.isEmpty() ? typeSpec.name() : packageName + "." + typeSpec.name();
         List<Element> originatingElements = typeSpec.originatingElements();
         JavaFileObject filerSourceFile = filer.createSourceFile(fileName, originatingElements.toArray(new Element[0]));
@@ -167,10 +169,12 @@ public final class JavaFile {
      * Returns the {@link Path} instance to which source is actually written.
      */
     public Path writeToPath(Path directory, Charset charset) throws IOException {
+        checkNotNull(directory, "directory == null");
         checkArgument(
                 Files.notExists(directory) || Files.isDirectory(directory),
                 "path %s exists but is not a directory.",
                 directory);
+        checkNotNull(charset, "charset == null");
         Path outputDirectory = directory;
         if (!packageName.isEmpty()) {
             for (String packageComponent : packageName.split("\\.", -1)) {
@@ -323,11 +327,10 @@ public final class JavaFile {
         }
 
         public Builder addStaticImport(ClassName className, String... names) {
-            checkArgument(className != null, "className == null");
-            checkArgument(names != null, "names == null");
+            checkNotNull(className, "className == null");
+            checkNoNullElement(names, "names");
             checkArgument(names.length > 0, "names array is empty");
             for (String name : names) {
-                checkArgument(name != null, "null entry in names array: %s", Arrays.toString(names));
                 staticImports.add(className.canonicalName() + "." + name);
             }
             return this;
@@ -347,7 +350,7 @@ public final class JavaFile {
         }
 
         public Builder indent(String indent) {
-            this.indent = indent;
+            this.indent = checkNotNull(indent, "indent == null");
             return this;
         }
 

--- a/javapoet/src/main/java/com/palantir/javapoet/MethodSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/MethodSpec.java
@@ -129,6 +129,10 @@ public final class MethodSpec {
         return name.equals(CONSTRUCTOR);
     }
 
+    public boolean isCompactRecordConstructor() {
+        return compactConstructor;
+    }
+
     private boolean lastParameterIsArray(List<ParameterSpec> parameters) {
         return !parameters.isEmpty()
                 && TypeName.asArray(parameters.get(parameters.size() - 1).type()) != null;

--- a/javapoet/src/main/java/com/palantir/javapoet/MethodSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/MethodSpec.java
@@ -18,6 +18,7 @@ package com.palantir.javapoet;
 import static com.palantir.javapoet.Util.checkArgument;
 import static com.palantir.javapoet.Util.checkNotNull;
 import static com.palantir.javapoet.Util.checkState;
+import static com.palantir.javapoet.Util.nonNullList;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -294,6 +295,10 @@ public final class MethodSpec {
      * parameters of the overridden method. Since JavaPoet 1.8 annotations must be added separately.
      */
     public static Builder overriding(ExecutableElement method, DeclaredType enclosing, Types types) {
+        checkNotNull(method, "method == null");
+        checkNotNull(enclosing, "enclosing == null");
+        checkNotNull(types, "types == null");
+
         ExecutableType executableType = (ExecutableType) types.asMemberOf(enclosing, method);
         List<? extends TypeMirror> resolvedParameterTypes = executableType.getParameterTypes();
         List<? extends TypeMirror> resolvedThrownTypes = executableType.getThrownTypes();
@@ -371,21 +376,21 @@ public final class MethodSpec {
         }
 
         public Builder addAnnotations(Iterable<AnnotationSpec> annotationSpecs) {
-            checkArgument(annotationSpecs != null, "annotationSpecs == null");
+            checkNotNull(annotationSpecs, "annotationSpecs == null");
             for (AnnotationSpec annotationSpec : annotationSpecs) {
-                this.annotations.add(annotationSpec);
+                addAnnotation(annotationSpec);
             }
             return this;
         }
 
         public Builder addAnnotation(AnnotationSpec annotationSpec) {
+            checkNotNull(annotationSpec, "annotationSpec == null");
             this.annotations.add(annotationSpec);
             return this;
         }
 
         public Builder addAnnotation(ClassName annotation) {
-            this.annotations.add(AnnotationSpec.builder(annotation).build());
-            return this;
+            return addAnnotation(AnnotationSpec.builder(annotation).build());
         }
 
         public Builder addAnnotation(Class<?> annotation) {
@@ -393,34 +398,35 @@ public final class MethodSpec {
         }
 
         public Builder addModifiers(Modifier... modifiers) {
-            checkNotNull(modifiers, "modifiers == null");
-            Collections.addAll(this.modifiers, modifiers);
-            return this;
+            return addModifiers(nonNullList(modifiers, "modifiers"));
         }
 
         public Builder addModifiers(Iterable<Modifier> modifiers) {
             checkNotNull(modifiers, "modifiers == null");
             for (Modifier modifier : modifiers) {
+                checkNotNull(modifier, "modifiers contain null");
                 this.modifiers.add(modifier);
             }
             return this;
         }
 
         public Builder addTypeVariables(Iterable<TypeVariableName> typeVariables) {
-            checkArgument(typeVariables != null, "typeVariables == null");
+            checkNotNull(typeVariables, "typeVariables == null");
             for (TypeVariableName typeVariable : typeVariables) {
-                this.typeVariables.add(typeVariable);
+                addTypeVariable(typeVariable);
             }
             return this;
         }
 
         public Builder addTypeVariable(TypeVariableName typeVariable) {
+            checkNotNull(typeVariable, "typeVariable == null");
             typeVariables.add(typeVariable);
             return this;
         }
 
         public Builder returns(TypeName returnType) {
             checkState(!name.equals(CONSTRUCTOR), "constructor cannot have return type.");
+            checkNotNull(returnType, "returnType == null");
             this.returnType = returnType;
             return this;
         }
@@ -430,14 +436,15 @@ public final class MethodSpec {
         }
 
         public Builder addParameters(Iterable<ParameterSpec> parameterSpecs) {
-            checkArgument(parameterSpecs != null, "parameterSpecs == null");
+            checkNotNull(parameterSpecs, "parameterSpecs == null");
             for (ParameterSpec parameterSpec : parameterSpecs) {
-                this.parameters.add(parameterSpec);
+                addParameter(parameterSpec);
             }
             return this;
         }
 
         public Builder addParameter(ParameterSpec parameterSpec) {
+            checkNotNull(parameterSpec, "parameterSpec == null");
             this.parameters.add(parameterSpec);
             return this;
         }
@@ -460,14 +467,15 @@ public final class MethodSpec {
         }
 
         public Builder addExceptions(Iterable<? extends TypeName> exceptions) {
-            checkArgument(exceptions != null, "exceptions == null");
+            checkNotNull(exceptions, "exceptions == null");
             for (TypeName exception : exceptions) {
-                this.exceptions.add(exception);
+                addException(exception);
             }
             return this;
         }
 
         public Builder addException(TypeName exception) {
+            checkNotNull(exception, "exception == null");
             this.exceptions.add(exception);
             return this;
         }
@@ -492,6 +500,7 @@ public final class MethodSpec {
         }
 
         public Builder addComment(String format, Object... args) {
+            checkNotNull(format, "format == null"); // otherwise string concat turns this into non-null
             code.add("// " + format + "\n", args);
             return this;
         }

--- a/javapoet/src/main/java/com/palantir/javapoet/MethodSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/MethodSpec.java
@@ -232,6 +232,11 @@ public final class MethodSpec {
         return new Builder(CONSTRUCTOR, false);
     }
 
+    /**
+     * Returns a builder for a compact record constructor, to be used with
+     * {@link TypeSpec.Builder#recordConstructor(MethodSpec)}. If you don't add any code to the
+     * constructor it does not matter whether you create a compact or non-compact constructor.
+     */
     public static Builder compactConstructorBuilder() {
         return new Builder(CONSTRUCTOR, true);
     }
@@ -513,6 +518,10 @@ public final class MethodSpec {
             return defaultValue(CodeBlock.of(format, args));
         }
 
+        /**
+         * Treats this method as an annotation type element and sets a default value for it. The
+         * built method is then only valid for annotation types, see {@link TypeSpec#annotationBuilder(String)}.
+         */
         public Builder defaultValue(CodeBlock codeBlock) {
             checkState(this.defaultValue == null, "defaultValue was already set");
             this.defaultValue = checkNotNull(codeBlock, "codeBlock == null");

--- a/javapoet/src/main/java/com/palantir/javapoet/NameAllocator.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/NameAllocator.java
@@ -127,6 +127,7 @@ public final class NameAllocator implements Cloneable {
     }
 
     public static String toJavaIdentifier(String suggestion) {
+        checkNotNull(suggestion, "suggestion == null");
         StringBuilder result = new StringBuilder();
         for (int i = 0; i < suggestion.length(); ) {
             int codePoint = suggestion.codePointAt(i);
@@ -143,6 +144,7 @@ public final class NameAllocator implements Cloneable {
 
     /** Retrieve a name created with {@link #newName(String, Object)}. */
     public String get(Object tag) {
+        checkNotNull(tag, "tag == null");
         String result = tagToName.get(tag);
         if (result == null) {
             throw new IllegalArgumentException("unknown tag: " + tag);

--- a/javapoet/src/main/java/com/palantir/javapoet/ParameterSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/ParameterSpec.java
@@ -130,6 +130,7 @@ public final class ParameterSpec {
     }
 
     private static boolean isValidParameterName(String name) {
+        checkNotNull(name, "name == null");
         // Allow "this" for explicit receiver parameters
         // See https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.1.
         if (name.endsWith(".this")) {
@@ -183,21 +184,21 @@ public final class ParameterSpec {
         }
 
         public Builder addAnnotations(Iterable<AnnotationSpec> annotationSpecs) {
-            checkArgument(annotationSpecs != null, "annotationSpecs == null");
+            checkNotNull(annotationSpecs, "annotationSpecs == null");
             for (AnnotationSpec annotationSpec : annotationSpecs) {
-                this.annotations.add(annotationSpec);
+                addAnnotation(annotationSpec);
             }
             return this;
         }
 
         public Builder addAnnotation(AnnotationSpec annotationSpec) {
+            checkNotNull(annotationSpec, "annotationSpec == null");
             this.annotations.add(annotationSpec);
             return this;
         }
 
         public Builder addAnnotation(ClassName annotation) {
-            this.annotations.add(AnnotationSpec.builder(annotation).build());
-            return this;
+            return addAnnotation(AnnotationSpec.builder(annotation).build());
         }
 
         public Builder addAnnotation(Class<?> annotation) {
@@ -212,6 +213,7 @@ public final class ParameterSpec {
         public Builder addModifiers(Iterable<Modifier> modifiers) {
             checkNotNull(modifiers, "modifiers == null");
             for (Modifier modifier : modifiers) {
+                checkNotNull(modifier, "modifiers contain null");
                 if (!modifier.equals(Modifier.FINAL)) {
                     throw new IllegalStateException("unexpected parameter modifier: " + modifier);
                 }

--- a/javapoet/src/main/java/com/palantir/javapoet/ParameterSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/ParameterSpec.java
@@ -17,12 +17,12 @@ package com.palantir.javapoet;
 
 import static com.palantir.javapoet.Util.checkArgument;
 import static com.palantir.javapoet.Util.checkNotNull;
+import static com.palantir.javapoet.Util.nonNullList;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import javax.lang.model.SourceVersion;
@@ -206,8 +206,7 @@ public final class ParameterSpec {
         }
 
         public Builder addModifiers(Modifier... modifiers) {
-            Collections.addAll(this.modifiers, modifiers);
-            return this;
+            return addModifiers(nonNullList(modifiers, "modifiers"));
         }
 
         public Builder addModifiers(Iterable<Modifier> modifiers) {

--- a/javapoet/src/main/java/com/palantir/javapoet/ParameterizedTypeName.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/ParameterizedTypeName.java
@@ -16,14 +16,15 @@
 package com.palantir.javapoet;
 
 import static com.palantir.javapoet.Util.checkArgument;
+import static com.palantir.javapoet.Util.checkNoNullElement;
 import static com.palantir.javapoet.Util.checkNotNull;
+import static com.palantir.javapoet.Util.nonNullList;
 
 import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +46,7 @@ public final class ParameterizedTypeName extends TypeName {
         super(annotations);
         this.rawType = checkNotNull(rawType, "rawType == null").annotated(annotations);
         this.enclosingType = enclosingType;
-        this.typeArguments = Util.immutableList(typeArguments);
+        this.typeArguments = Util.immutableList(checkNoNullElement(typeArguments, "typeArguments"));
 
         checkArgument(!this.typeArguments.isEmpty() || enclosingType != null, "no type arguments: %s", rawType);
         for (TypeName typeArgument : this.typeArguments) {
@@ -124,7 +125,7 @@ public final class ParameterizedTypeName extends TypeName {
 
     /** Returns a parameterized type, applying {@code typeArguments} to {@code rawType}. */
     public static ParameterizedTypeName get(ClassName rawType, TypeName... typeArguments) {
-        return new ParameterizedTypeName(null, rawType, Arrays.asList(typeArguments));
+        return new ParameterizedTypeName(null, rawType, nonNullList(typeArguments, "typeArguments"));
     }
 
     /** Returns a parameterized type, applying {@code typeArguments} to {@code rawType}. */
@@ -139,6 +140,7 @@ public final class ParameterizedTypeName extends TypeName {
 
     /** Returns a parameterized type equivalent to {@code type}. */
     static ParameterizedTypeName get(ParameterizedType type, Map<Type, TypeVariableName> map) {
+        checkNotNull(type, "type == null");
         ClassName rawType = ClassName.get((Class<?>) type.getRawType());
         List<TypeName> typeArguments = TypeName.list(type.getActualTypeArguments(), map);
 

--- a/javapoet/src/main/java/com/palantir/javapoet/TypeName.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/TypeName.java
@@ -15,6 +15,10 @@
  */
 package com.palantir.javapoet;
 
+import static com.palantir.javapoet.Util.checkNoNullElement;
+import static com.palantir.javapoet.Util.checkNotNull;
+import static com.palantir.javapoet.Util.nonNullList;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.GenericArrayType;
@@ -23,7 +27,6 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -91,7 +94,7 @@ public class TypeName {
 
     private TypeName(String keyword, List<AnnotationSpec> annotations) {
         this.keyword = keyword;
-        this.annotations = Util.immutableList(annotations);
+        this.annotations = Util.immutableList(checkNoNullElement(annotations, "annotations"));
     }
 
     // Package-private constructor to prevent third-party subclasses.
@@ -104,11 +107,11 @@ public class TypeName {
     }
 
     public final TypeName annotated(AnnotationSpec... annotations) {
-        return annotated(Arrays.asList(annotations));
+        return annotated(nonNullList(annotations, "annotations"));
     }
 
     public TypeName annotated(List<AnnotationSpec> annotations) {
-        Util.checkNotNull(annotations, "annotations == null");
+        checkNotNull(annotations, "annotations == null");
         return new TypeName(keyword, concatAnnotations(annotations));
     }
 
@@ -119,9 +122,9 @@ public class TypeName {
         return new TypeName(keyword);
     }
 
-    protected final List<AnnotationSpec> concatAnnotations(List<AnnotationSpec> annotations) {
+    final List<AnnotationSpec> concatAnnotations(List<AnnotationSpec> annotations) {
         List<AnnotationSpec> allAnnotations = new ArrayList<>(this.annotations);
-        allAnnotations.addAll(annotations);
+        allAnnotations.addAll(checkNoNullElement(annotations, "annotations"));
         return allAnnotations;
     }
 
@@ -285,6 +288,7 @@ public class TypeName {
     }
 
     static TypeName get(TypeMirror mirror, final Map<TypeParameterElement, TypeVariableName> typeVariables) {
+        checkNotNull(mirror, "mirror == null");
         return mirror.accept(
                 new SimpleTypeVisitor8<TypeName, Void>() {
                     @Override
@@ -422,6 +426,7 @@ public class TypeName {
     }
 
     static List<TypeName> list(Type[] types, Map<Type, TypeVariableName> map) {
+        checkNoNullElement(types, "types");
         List<TypeName> result = new ArrayList<>(types.length);
         for (Type type : types) {
             result.add(get(type, map));

--- a/javapoet/src/main/java/com/palantir/javapoet/TypeSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/TypeSpec.java
@@ -754,8 +754,8 @@ public final class TypeSpec {
          */
         public Builder recordConstructor(MethodSpec recordConstructor) {
             checkState(this.kind == Kind.RECORD, "%s can't have record constructor", this.kind);
-            checkState(this.recordConstructor == null, "record constructor already set to %s", this.recordConstructor);
-            checkArgument(recordConstructor.isConstructor(), "must provide a constructor, not %s", recordConstructor);
+            checkState(this.recordConstructor == null, "record constructor already set");
+            checkArgument(recordConstructor.isConstructor(), "must provide a constructor, not a regular method");
             this.recordConstructor = recordConstructor;
             return this;
         }

--- a/javapoet/src/main/java/com/palantir/javapoet/TypeSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/TypeSpec.java
@@ -16,6 +16,7 @@
 package com.palantir.javapoet;
 
 import static com.palantir.javapoet.Util.checkArgument;
+import static com.palantir.javapoet.Util.checkNoNullElement;
 import static com.palantir.javapoet.Util.checkNotNull;
 import static com.palantir.javapoet.Util.checkState;
 import static com.palantir.javapoet.Util.requireExactlyOneOf;
@@ -234,6 +235,7 @@ public final class TypeSpec {
     }
 
     public static Builder anonymousClassBuilder(CodeBlock typeArguments) {
+        checkNotNull(typeArguments, "typeArguments == null");
         return new Builder(Kind.CLASS, null, typeArguments);
     }
 
@@ -611,9 +613,9 @@ public final class TypeSpec {
         }
 
         public Builder addAnnotations(Iterable<AnnotationSpec> annotationSpecs) {
-            checkArgument(annotationSpecs != null, "annotationSpecs == null");
+            checkNotNull(annotationSpecs, "annotationSpecs == null");
             for (AnnotationSpec annotationSpec : annotationSpecs) {
-                this.annotations.add(annotationSpec);
+                addAnnotation(annotationSpec);
             }
             return this;
         }
@@ -633,26 +635,27 @@ public final class TypeSpec {
         }
 
         public Builder addModifiers(Modifier... modifiers) {
-            Collections.addAll(this.modifiers, modifiers);
+            Collections.addAll(this.modifiers, checkNoNullElement(modifiers, "modifiers"));
             return this;
         }
 
         public Builder addTypeVariables(Iterable<TypeVariableName> typeVariables) {
-            checkArgument(typeVariables != null, "typeVariables == null");
+            checkNotNull(typeVariables, "typeVariables == null");
             for (TypeVariableName typeVariable : typeVariables) {
-                this.typeVariables.add(typeVariable);
+                addTypeVariable(typeVariable);
             }
             return this;
         }
 
         public Builder addTypeVariable(TypeVariableName typeVariable) {
+            checkNotNull(typeVariable, "typeVariable == null");
             typeVariables.add(typeVariable);
             return this;
         }
 
         public Builder superclass(TypeName superclass) {
-            checkState(this.kind == Kind.CLASS, "only classes have super classes, not " + this.kind);
-            checkState(this.superclass == ClassName.OBJECT, "superclass already set to " + this.superclass);
+            checkState(this.kind == Kind.CLASS, "only classes have super classes, not %s", this.kind);
+            checkState(this.superclass == ClassName.OBJECT, "superclass already set to %s", this.superclass);
             checkArgument(!superclass.isPrimitive(), "superclass may not be a primitive");
             this.superclass = superclass;
             return this;
@@ -687,7 +690,7 @@ public final class TypeSpec {
         }
 
         public Builder addSuperinterfaces(Iterable<? extends TypeName> superinterfaces) {
-            checkArgument(superinterfaces != null, "superinterfaces == null");
+            checkNotNull(superinterfaces, "superinterfaces == null");
             for (TypeName superinterface : superinterfaces) {
                 addSuperinterface(superinterface);
             }
@@ -695,7 +698,7 @@ public final class TypeSpec {
         }
 
         public Builder addSuperinterface(TypeName superinterface) {
-            checkArgument(superinterface != null, "superinterface == null");
+            checkNotNull(superinterface, "superinterface == null");
             this.superinterfaces.add(superinterface);
             return this;
         }
@@ -737,7 +740,7 @@ public final class TypeSpec {
         }
 
         public Builder addPermittedSubclasses(Iterable<? extends TypeName> permittedSubclasses) {
-            checkArgument(permittedSubclasses != null, "permittedSubclasses == null");
+            checkNotNull(permittedSubclasses, "permittedSubclasses == null");
             for (TypeName permittedSubclass : permittedSubclasses) {
                 addPermittedSubclass(permittedSubclass);
             }
@@ -747,8 +750,8 @@ public final class TypeSpec {
         public Builder addPermittedSubclass(TypeName permittedSubclass) {
             checkState(
                     this.kind == Kind.CLASS || this.kind == Kind.INTERFACE,
-                    "only classes and interfaces can have permitted subclasses, not " + this.kind);
-            checkArgument(permittedSubclass != null, "permittedSubclass == null");
+                    "only classes and interfaces can have permitted subclasses, not %s", this.kind);
+            checkNotNull(permittedSubclass, "permittedSubclass == null");
             this.permittedSubclasses.add(permittedSubclass);
             return this;
         }
@@ -786,12 +789,14 @@ public final class TypeSpec {
         }
 
         public Builder addEnumConstant(String name, TypeSpec typeSpec) {
+            checkNotNull(name, "name == null");
+            checkNotNull(typeSpec, "typeSpec == null");
             enumConstants.put(name, typeSpec);
             return this;
         }
 
         public Builder addFields(Iterable<FieldSpec> fieldSpecs) {
-            checkArgument(fieldSpecs != null, "fieldSpecs == null");
+            checkNotNull(fieldSpecs, "fieldSpecs == null");
             for (FieldSpec fieldSpec : fieldSpecs) {
                 addField(fieldSpec);
             }
@@ -799,6 +804,7 @@ public final class TypeSpec {
         }
 
         public Builder addField(FieldSpec fieldSpec) {
+            checkNotNull(fieldSpec, "fieldSpec == null");
             fieldSpecs.add(fieldSpec);
             return this;
         }
@@ -825,7 +831,7 @@ public final class TypeSpec {
         }
 
         public Builder addMethods(Iterable<MethodSpec> methodSpecs) {
-            checkArgument(methodSpecs != null, "methodSpecs == null");
+            checkNotNull(methodSpecs, "methodSpecs == null");
             for (MethodSpec methodSpec : methodSpecs) {
                 addMethod(methodSpec);
             }
@@ -833,12 +839,13 @@ public final class TypeSpec {
         }
 
         public Builder addMethod(MethodSpec methodSpec) {
+            checkNotNull(methodSpec, "methodSpec == null");
             methodSpecs.add(methodSpec);
             return this;
         }
 
         public Builder addTypes(Iterable<TypeSpec> typeSpecs) {
-            checkArgument(typeSpecs != null, "typeSpecs == null");
+            checkNotNull(typeSpecs, "typeSpecs == null");
             for (TypeSpec typeSpec : typeSpecs) {
                 addType(typeSpec);
             }
@@ -846,21 +853,20 @@ public final class TypeSpec {
         }
 
         public Builder addType(TypeSpec typeSpec) {
+            checkNotNull(typeSpec, "typeSpec == null");
             typeSpecs.add(typeSpec);
             return this;
         }
 
         public Builder addOriginatingElement(Element originatingElement) {
+            checkNotNull(originatingElement, "originatingElement == null");
             originatingElements.add(originatingElement);
             return this;
         }
 
         public Builder alwaysQualify(String... simpleNames) {
-            checkArgument(simpleNames != null, "simpleNames == null");
-            for (String name : simpleNames) {
-                checkArgument(name != null, "null entry in simpleNames array: %s", Arrays.toString(simpleNames));
-                alwaysQualifiedNames.add(name);
-            }
+            checkNoNullElement(simpleNames, "simpleNames");
+            Collections.addAll(alwaysQualifiedNames, simpleNames);
             return this;
         }
 
@@ -889,7 +895,7 @@ public final class TypeSpec {
          * @return this builder instance
          */
         public Builder avoidClashesWithNestedClasses(TypeElement typeElement) {
-            checkArgument(typeElement != null, "typeElement == null");
+            checkNotNull(typeElement, "typeElement == null");
             for (TypeElement nestedType : ElementFilter.typesIn(typeElement.getEnclosedElements())) {
                 alwaysQualify(nestedType.getSimpleName().toString());
             }
@@ -932,7 +938,7 @@ public final class TypeSpec {
          * @return this builder instance
          */
         public Builder avoidClashesWithNestedClasses(Class<?> clazz) {
-            checkArgument(clazz != null, "clazz == null");
+            checkNotNull(clazz, "clazz == null");
             for (Class<?> nestedType : clazz.getDeclaredClasses()) {
                 alwaysQualify(nestedType.getSimpleName());
             }
@@ -954,7 +960,7 @@ public final class TypeSpec {
             if (!modifiers.isEmpty()) {
                 checkState(anonymousTypeArguments == null, "forbidden on anonymous types.");
                 for (Modifier modifier : modifiers) {
-                    checkArgument(modifier != null, "modifiers contain null");
+                    checkNotNull(modifier, "modifiers contain null");
                 }
             }
 
@@ -964,19 +970,12 @@ public final class TypeSpec {
                 }
             }
 
-            for (TypeName superinterface : superinterfaces) {
-                checkArgument(superinterface != null, "superinterfaces contains null");
-            }
-
-            for (TypeName superinterface : permittedSubclasses) {
-                checkArgument(superinterface != null, "permittedSubclasses contains null");
-            }
+            checkNoNullElement(superinterfaces, "superinterfaces");
+            checkNoNullElement(permittedSubclasses, "permittedSubclasses");
 
             if (!typeVariables.isEmpty()) {
-                checkState(anonymousTypeArguments == null, "typevariables are forbidden on anonymous types.");
-                for (TypeVariableName typeVariableName : typeVariables) {
-                    checkArgument(typeVariableName != null, "typeVariables contain null");
-                }
+                checkState(anonymousTypeArguments == null, "typeVariables are forbidden on anonymous types.");
+                checkNoNullElement(typeVariables, "typeVariables");
             }
 
             for (Map.Entry<String, TypeSpec> enumConstant : enumConstants.entrySet()) {

--- a/javapoet/src/main/java/com/palantir/javapoet/TypeSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/TypeSpec.java
@@ -19,6 +19,7 @@ import static com.palantir.javapoet.Util.checkArgument;
 import static com.palantir.javapoet.Util.checkNoNullElement;
 import static com.palantir.javapoet.Util.checkNotNull;
 import static com.palantir.javapoet.Util.checkState;
+import static com.palantir.javapoet.Util.nonNullList;
 import static com.palantir.javapoet.Util.requireExactlyOneOf;
 
 import java.io.IOException;
@@ -643,7 +644,15 @@ public final class TypeSpec {
         }
 
         public Builder addModifiers(Modifier... modifiers) {
-            Collections.addAll(this.modifiers, checkNoNullElement(modifiers, "modifiers"));
+            return addModifiers(nonNullList(modifiers, "modifiers"));
+        }
+
+        public Builder addModifiers(Iterable<Modifier> modifiers) {
+            checkNotNull(modifiers, "modifiers == null");
+            for (Modifier modifier : modifiers) {
+                checkNotNull(modifier, "modifiers contain null");
+                this.modifiers.add(modifier);
+            }
             return this;
         }
 

--- a/javapoet/src/main/java/com/palantir/javapoet/Util.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/Util.java
@@ -63,6 +63,27 @@ final class Util {
         return reference;
     }
 
+    static <T> T[] checkNoNullElement(T[] array, String name) {
+        checkNotNull(array, "%s == null", name);
+        for (T element : array) {
+            checkNotNull(element, "%s contain null", name);
+        }
+        return array;
+    }
+
+    static <C extends Collection<?>> C checkNoNullElement(C collection, String name) {
+        checkNotNull(collection, "%s == null", name);
+        for (Object element : collection) {
+            checkNotNull(element, "%s contain null", name);
+        }
+        return collection;
+    }
+
+    static <T> List<T> nonNullList(T[] args, String name) {
+        checkNoNullElement(args, name);
+        return Arrays.asList(args);
+    }
+
     static void checkState(boolean condition, String format, Object... args) {
         if (!condition) {
             throw new IllegalStateException(String.format(format, args));

--- a/javapoet/src/main/java/com/palantir/javapoet/WildcardTypeName.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/WildcardTypeName.java
@@ -16,6 +16,8 @@
 package com.palantir.javapoet;
 
 import static com.palantir.javapoet.Util.checkArgument;
+import static com.palantir.javapoet.Util.checkNoNullElement;
+import static com.palantir.javapoet.Util.checkNotNull;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -38,8 +40,8 @@ public final class WildcardTypeName extends TypeName {
 
     private WildcardTypeName(List<TypeName> upperBounds, List<TypeName> lowerBounds, List<AnnotationSpec> annotations) {
         super(annotations);
-        this.upperBounds = Util.immutableList(upperBounds);
-        this.lowerBounds = Util.immutableList(lowerBounds);
+        this.upperBounds = Util.immutableList(checkNoNullElement(upperBounds, "upperBounds"));
+        this.lowerBounds = Util.immutableList(checkNoNullElement(lowerBounds, "lowerBounds"));
 
         checkArgument(this.upperBounds.size() == 1, "unexpected extends bounds: %s", upperBounds);
         for (TypeName upperBound : this.upperBounds) {
@@ -104,11 +106,13 @@ public final class WildcardTypeName extends TypeName {
     }
 
     public static TypeName get(javax.lang.model.type.WildcardType mirror) {
+        checkNotNull(mirror, "mirror == null");
         return get(mirror, new LinkedHashMap<>());
     }
 
     static TypeName get(
             javax.lang.model.type.WildcardType mirror, Map<TypeParameterElement, TypeVariableName> typeVariables) {
+        checkNotNull(mirror, "mirror == null");
         TypeMirror extendsBound = mirror.getExtendsBound();
         if (extendsBound == null) {
             TypeMirror superBound = mirror.getSuperBound();

--- a/javapoet/src/test/java/com/palantir/javapoet/AnnotationSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/AnnotationSpecTest.java
@@ -374,9 +374,8 @@ public final class AnnotationSpecTest {
 
     @Test
     public void disallowsNullMemberName() {
-        AnnotationSpec.Builder builder =
-                AnnotationSpec.builder(HasDefaultsAnnotation.class).addMember(null, "$L", "");
-        assertThatThrownBy(() -> builder.build().toString())
+        AnnotationSpec.Builder builder = AnnotationSpec.builder(HasDefaultsAnnotation.class);
+        assertThatThrownBy(() -> builder.addMember(null, "$L", ""))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("name == null");
     }

--- a/javapoet/src/test/java/com/palantir/javapoet/FieldSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/FieldSpecTest.java
@@ -41,7 +41,7 @@ public class FieldSpecTest {
     @Test
     public void nullAnnotationsAddition() {
         assertThatThrownBy(() -> FieldSpec.builder(int.class, "foo").addAnnotations(null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(NullPointerException.class)
                 .hasMessage("annotationSpecs == null");
     }
 }

--- a/javapoet/src/test/java/com/palantir/javapoet/MethodSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/MethodSpecTest.java
@@ -403,6 +403,14 @@ public final class MethodSpecTest {
     }
 
     @Test
+    public void defaultValueAlreadySet() {
+        MethodSpec.Builder builder = MethodSpec.methodBuilder("name").defaultValue("true");
+        assertThatThrownBy(() -> builder.defaultValue("false"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("defaultValue was already set");
+    }
+
+    @Test
     public void ensureTrailingNewline() {
         MethodSpec methodSpec = MethodSpec.methodBuilder("method")
                 .addCode("codeWithNoNewline();")

--- a/javapoet/src/test/java/com/palantir/javapoet/MethodSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/MethodSpecTest.java
@@ -68,28 +68,28 @@ public final class MethodSpecTest {
     @Test
     public void nullAnnotationsAddition() {
         assertThatThrownBy(() -> MethodSpec.methodBuilder("doSomething").addAnnotations(null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(NullPointerException.class)
                 .hasMessage("annotationSpecs == null");
     }
 
     @Test
     public void nullTypeVariablesAddition() {
         assertThatThrownBy(() -> MethodSpec.methodBuilder("doSomething").addTypeVariables(null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(NullPointerException.class)
                 .hasMessage("typeVariables == null");
     }
 
     @Test
     public void nullParametersAddition() {
         assertThatThrownBy(() -> MethodSpec.methodBuilder("doSomething").addParameters(null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(NullPointerException.class)
                 .hasMessage("parameterSpecs == null");
     }
 
     @Test
     public void nullExceptionsAddition() {
         assertThatThrownBy(() -> MethodSpec.methodBuilder("doSomething").addExceptions(null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(NullPointerException.class)
                 .hasMessage("exceptions == null");
     }
 

--- a/javapoet/src/test/java/com/palantir/javapoet/ParameterSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/ParameterSpecTest.java
@@ -57,8 +57,8 @@ public class ParameterSpecTest {
         assertThat(a.equals(b)).isTrue();
         assertThat(a.hashCode()).isEqualTo(b.hashCode());
         assertThat(a.toString()).isEqualTo(b.toString());
-        a = ParameterSpec.builder(int.class, "i").addModifiers(Modifier.STATIC).build();
-        b = ParameterSpec.builder(int.class, "i").addModifiers(Modifier.STATIC).build();
+        a = ParameterSpec.builder(int.class, "i").addModifiers(Modifier.FINAL).build();
+        b = ParameterSpec.builder(int.class, "i").addModifiers(Modifier.FINAL).build();
         assertThat(a.equals(b)).isTrue();
         assertThat(a.hashCode()).isEqualTo(b.hashCode());
         assertThat(a.toString()).isEqualTo(b.toString());

--- a/javapoet/src/test/java/com/palantir/javapoet/TypeSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/TypeSpecTest.java
@@ -2084,6 +2084,13 @@ public final class TypeSpecTest {
     }
 
     @Test
+    public void nullAnonymousClass() {
+        assertThatThrownBy(() -> TypeSpec.anonymousClassBuilder(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("typeArguments == null");
+    }
+
+    @Test
     public void interfaceClassToString() {
         TypeSpec type = TypeSpec.interfaceBuilder("Taco").build();
         assertThat(type.toString())
@@ -2245,7 +2252,7 @@ public final class TypeSpecTest {
     @Test
     public void nullAnnotationsAddition() {
         assertThatThrownBy(() -> TypeSpec.classBuilder("Taco").addAnnotations(null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(NullPointerException.class)
                 .hasMessage("annotationSpecs == null");
     }
 
@@ -2276,7 +2283,7 @@ public final class TypeSpecTest {
     @Test
     public void nullFieldsAddition() {
         assertThatThrownBy(() -> TypeSpec.classBuilder("Taco").addFields(null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(NullPointerException.class)
                 .hasMessage("fieldSpecs == null");
     }
 
@@ -2307,7 +2314,7 @@ public final class TypeSpecTest {
     @Test
     public void nullMethodsAddition() {
         assertThatThrownBy(() -> TypeSpec.classBuilder("Taco").addMethods(null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(NullPointerException.class)
                 .hasMessage("methodSpecs == null");
     }
 
@@ -2350,14 +2357,14 @@ public final class TypeSpecTest {
     @Test
     public void nullSuperinterfacesAddition() {
         assertThatThrownBy(() -> TypeSpec.classBuilder("Taco").addSuperinterfaces(null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(NullPointerException.class)
                 .hasMessage("superinterfaces == null");
     }
 
     @Test
     public void nullSingleSuperinterfaceAddition() {
         assertThatThrownBy(() -> TypeSpec.classBuilder("Taco").addSuperinterface((TypeName) null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(NullPointerException.class)
                 .hasMessage("superinterface == null");
     }
 
@@ -2368,7 +2375,7 @@ public final class TypeSpecTest {
         superinterfaces.add(null);
 
         assertThatThrownBy(() -> TypeSpec.classBuilder("Taco").addSuperinterfaces(superinterfaces))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(NullPointerException.class)
                 .hasMessage("superinterface == null");
     }
 
@@ -2393,14 +2400,14 @@ public final class TypeSpecTest {
     @Test
     public void nullPermittedSubclassesAddition() {
         assertThatThrownBy(() -> TypeSpec.classBuilder("Taco").addPermittedSubclasses(null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(NullPointerException.class)
                 .hasMessage("permittedSubclasses == null");
     }
 
     @Test
     public void nullPermittedSubclassAddition() {
         assertThatThrownBy(() -> TypeSpec.classBuilder("Taco").addPermittedSubclass((TypeName) null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(NullPointerException.class)
                 .hasMessage("permittedSubclass == null");
     }
 
@@ -2411,7 +2418,7 @@ public final class TypeSpecTest {
         permittedSublclasses.add(null);
 
         assertThatThrownBy(() -> TypeSpec.classBuilder("Taco").addPermittedSubclasses(permittedSublclasses))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(NullPointerException.class)
                 .hasMessage("permittedSubclass == null");
     }
 
@@ -2438,14 +2445,14 @@ public final class TypeSpecTest {
         assertThatThrownBy(() -> TypeSpec.classBuilder("Taco")
                         .addModifiers((Modifier) null)
                         .build())
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(NullPointerException.class)
                 .hasMessage("modifiers contain null");
     }
 
     @Test
     public void nullTypeVariablesAddition() {
         assertThatThrownBy(() -> TypeSpec.classBuilder("Taco").addTypeVariables(null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(NullPointerException.class)
                 .hasMessage("typeVariables == null");
     }
 
@@ -2469,7 +2476,7 @@ public final class TypeSpecTest {
     @Test
     public void nullTypesAddition() {
         assertThatThrownBy(() -> TypeSpec.classBuilder("Taco").addTypes(null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(NullPointerException.class)
                 .hasMessage("typeSpecs == null");
     }
 

--- a/javapoet/src/test/java/com/palantir/javapoet/TypeSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/TypeSpecTest.java
@@ -1000,7 +1000,7 @@ public final class TypeSpecTest {
         TypeSpec.Builder builder = TypeSpec.recordBuilder("Taco").recordConstructor(constructor);
         assertThatThrownBy(() -> builder.recordConstructor(constructor))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageStartingWith("record constructor already set to ");
+                .hasMessage("record constructor already set");
     }
 
     @Test
@@ -1008,7 +1008,7 @@ public final class TypeSpecTest {
         MethodSpec method = MethodSpec.methodBuilder("test").build();
         assertThatThrownBy(() -> TypeSpec.recordBuilder("Taco").recordConstructor(method))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("must provide a constructor, not ");
+                .hasMessage("must provide a constructor, not a regular method");
     }
 
     @Test


### PR DESCRIPTION
Resolves #342

## Before this PR
- Builder methods were not consistently checking for `null`
This would probably often have lead to delayed `NullPointerException`s, or might have even caused different behavior in case `null` had internally a special meaning.
- Thrown exception types were not consistent
Sometimes `IllegalArgumentException` was thrown for `null`; in two cases `UnsupportedOperationException` was thrown instead of `IllegalStateException`.
- Validation was missing for adding record constructors
- Some validation only happened during `build()`, and not already when calling builder methods
**Note:** I only changed a few cases; maybe would be worth to investigate this more in depth in the future. But this applies mainly to immutable state of a builder, e.g. a `TypeSpec.Builder` for `class` will keep that kind and it cannot be changed to `enum`. For other validation is probably fine and better to do this in `build()`.

## After this PR
- `NullPointerException` is thrown for unexpected `null`
- `IllegalStateException` is thrown when methods are called on wrong type, e.g. adding record constructor to regular class
- Exceptions are thrown for incorrect record constructor usage
- Added `addModifier(Iterable)` overloads, see https://github.com/palantir/javapoet/pull/85#discussion_r1775779088

## Possible downsides?
I hope these changes do not accidentally disallow arguments which should be allowed.
