### PR TITLE
Add MethodSpec.Builder.clearModifiers() method

### DIFF
--- a/changelog/@unreleased/pr-114.v2.yml
+++ b/changelog/@unreleased/pr-114.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add MethodSpec.Builder.clearModifiers() method
+  links:
+  - https://github.com/palantir/javapoet/pull/114

--- a/javapoet/src/main/java/com/palantir/javapoet/MethodSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/MethodSpec.java
@@ -406,6 +406,11 @@ public final class MethodSpec {
             return this;
         }
 
+        public Builder clearModifiers() {
+            this.modifiers.clear();
+            return this;
+        }
+
         public Builder addTypeVariables(Iterable<TypeVariableName> typeVariables) {
             checkArgument(typeVariables != null, "typeVariables == null");
             for (TypeVariableName typeVariable : typeVariables) {

--- a/javapoet/src/test/java/com/palantir/javapoet/MethodSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/MethodSpecTest.java
@@ -389,6 +389,31 @@ public final class MethodSpecTest {
     }
 
     @Test
+    public void clearModifiers() {
+        MethodSpec method = MethodSpec.methodBuilder("getRandomNumber")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .returns(TypeName.INT)
+                .addCode("return 4; // chosen by fair dice roll. guaranteed to be random.")
+                .build();
+        assertThat(method.toString())
+                .isEqualTo(
+                        """
+                        public static int getRandomNumber() {
+                          return 4; // chosen by fair dice roll. guaranteed to be random.
+                        }
+                        """);
+
+        MethodSpec updatedMethod = method.toBuilder().clearModifiers().build();
+        assertThat(updatedMethod.toString())
+                .isEqualTo(
+                        """
+                        int getRandomNumber() {
+                          return 4; // chosen by fair dice roll. guaranteed to be random.
+                        }
+                        """);
+    }
+
+    @Test
     public void modifyMethodName() {
         MethodSpec methodSpec = MethodSpec.methodBuilder("initialMethod").build().toBuilder()
                 .setName("revisedMethod")


### PR DESCRIPTION
## Before this PR
Can't easily migrate palantir/safe-logging's usage pattern [here](https://github.com/palantir/safe-logging/blob/ae76dad85eb02d750c0bc72f1f308d21a5b0eb4c/logger-generator/src/main/java/com/palantir/logsafe/logger/generator/LoggerGenerator.java#L99-L100) because Palantir javapoet made MethodSpec.Builder.modifiers to be append-only, but that usage clears the modifiers.

## After this PR
==COMMIT_MSG==
Add MethodSpec.Builder.clearModifiers() method
==COMMIT_MSG==

## Possible downsides?
None known