### PR TITLE
Fix: Add resolve for typeVariables in MethodSpec (#117)

### DIFF
--- a/javapoet/src/main/java/com/palantir/javapoet/MethodSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/MethodSpec.java
@@ -35,6 +35,7 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 import javax.lang.model.util.Types;
@@ -295,6 +296,7 @@ public final class MethodSpec {
      */
     public static Builder overriding(ExecutableElement method, DeclaredType enclosing, Types types) {
         ExecutableType executableType = (ExecutableType) types.asMemberOf(enclosing, method);
+        List<? extends TypeVariable> resolvedTypeVariables = executableType.getTypeVariables();
         List<? extends TypeMirror> resolvedParameterTypes = executableType.getParameterTypes();
         List<? extends TypeMirror> resolvedThrownTypes = executableType.getThrownTypes();
         TypeMirror resolvedReturnType = executableType.getReturnType();
@@ -306,6 +308,18 @@ public final class MethodSpec {
             TypeName type = TypeName.get(resolvedParameterTypes.get(i));
             builder.parameters.set(
                     i, parameter.toBuilder(type, parameter.name()).build());
+        }
+        for (int i = 0, size = builder.typeVariables.size(); i < size; i++) {
+            String name =
+                    resolvedTypeVariables.get(i).asElement().getSimpleName().toString();
+            List<TypeName> bounds = new ArrayList<>();
+            if (resolvedTypeVariables.get(i).getUpperBound().getKind() != TypeKind.NULL) {
+                bounds.add(TypeName.get(resolvedTypeVariables.get(i).getUpperBound()));
+            }
+            if (resolvedTypeVariables.get(i).getLowerBound().getKind() != TypeKind.NULL) {
+                bounds.add(TypeName.get(resolvedTypeVariables.get(i).getLowerBound()));
+            }
+            builder.typeVariables.set(i, TypeVariableName.get(name, bounds.toArray(new TypeName[0])));
         }
         builder.exceptions.clear();
         for (TypeMirror resolvedThrownType : resolvedThrownTypes) {

--- a/javapoet/src/main/java/com/palantir/javapoet/MethodSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/MethodSpec.java
@@ -310,14 +310,11 @@ public final class MethodSpec {
                     i, parameter.toBuilder(type, parameter.name()).build());
         }
         for (int i = 0, size = builder.typeVariables.size(); i < size; i++) {
-            String name =
-                    resolvedTypeVariables.get(i).asElement().getSimpleName().toString();
+            TypeVariable resolvedTypeVariable = resolvedTypeVariables.get(i);
+            String name = resolvedTypeVariable.asElement().getSimpleName().toString();
             List<TypeName> bounds = new ArrayList<>();
             if (resolvedTypeVariables.get(i).getUpperBound().getKind() != TypeKind.NULL) {
                 bounds.add(TypeName.get(resolvedTypeVariables.get(i).getUpperBound()));
-            }
-            if (resolvedTypeVariables.get(i).getLowerBound().getKind() != TypeKind.NULL) {
-                bounds.add(TypeName.get(resolvedTypeVariables.get(i).getLowerBound()));
             }
             builder.typeVariables.set(i, TypeVariableName.get(name, bounds.toArray(new TypeName[0])));
         }

--- a/javapoet/src/main/java/com/palantir/javapoet/MethodSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/MethodSpec.java
@@ -313,8 +313,8 @@ public final class MethodSpec {
             TypeVariable resolvedTypeVariable = resolvedTypeVariables.get(i);
             String name = resolvedTypeVariable.asElement().getSimpleName().toString();
             List<TypeName> bounds = new ArrayList<>();
-            if (resolvedTypeVariables.get(i).getUpperBound().getKind() != TypeKind.NULL) {
-                bounds.add(TypeName.get(resolvedTypeVariables.get(i).getUpperBound()));
+            if (resolvedTypeVariable.getUpperBound().getKind() != TypeKind.NULL) {
+                bounds.add(TypeName.get(resolvedTypeVariable.getUpperBound()));
             }
             builder.typeVariables.set(i, TypeVariableName.get(name, bounds.toArray(new TypeName[0])));
         }

--- a/javapoet/src/test/java/com/palantir/javapoet/MethodSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/MethodSpecTest.java
@@ -117,7 +117,11 @@ public final class MethodSpecTest {
         void fail() throws R;
     }
 
-    interface ExtendsOthers extends Callable<Integer>, Comparable<ExtendsOthers>, Throws<IllegalStateException> {}
+    interface CustomExtensible<T> {
+        <S extends T> void doStuff(S input);
+    }
+
+    interface ExtendsOthers extends Callable<Integer>, Comparable<ExtendsOthers>, Throws<IllegalStateException>, CustomExtensible<Double> {}
 
     interface ExtendsIterableWithDefaultMethods extends Iterable<Object> {}
 
@@ -225,6 +229,15 @@ public final class MethodSpecTest {
                         """
                         @java.lang.Override
                         public void fail() throws java.lang.IllegalStateException {
+                        }
+                        """);
+        exec = findFirst(methods, "doStuff");
+        method = MethodSpec.overriding(exec, classType, types).build();
+        assertThat(method.toString())
+                .isEqualTo(
+                        """
+                        @java.lang.Override
+                        public <S extends java.lang.Double> void doStuff(S input) {
                         }
                         """);
     }

--- a/javapoet/src/test/java/com/palantir/javapoet/MethodSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/MethodSpecTest.java
@@ -121,7 +121,11 @@ public final class MethodSpecTest {
         <S extends T> void doStuff(S input);
     }
 
-    interface ExtendsOthers extends Callable<Integer>, Comparable<ExtendsOthers>, Throws<IllegalStateException>, CustomExtensible<Double> {}
+    interface ExtendsOthers
+            extends Callable<Integer>,
+                    Comparable<ExtendsOthers>,
+                    Throws<IllegalStateException>,
+                    CustomExtensible<Double> {}
 
     interface ExtendsIterableWithDefaultMethods extends Iterable<Object> {}
 


### PR DESCRIPTION
## Before this PR
As described in the linked issue, Generics which are bounded by another generic type, are not correctly overridden by the `MethodSpec.overriding()` Method.

## After this PR
==COMMIT_MSG==
Fix: Add resolve for typeVariables in MethodSpec (#117 )
==COMMIT_MSG==

## Possible downsides?
None obvious to me.
There may be edge cases not covered by unit tests that are affected by this change.

