### PR TITLE
Refine the return type of TypeName.withoutAnnotations in subclasses

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,0 +1,23 @@
+acceptedBreaks:
+  "0.13.0":
+    com.palantir.javapoet:javapoet:
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method com.palantir.javapoet.TypeName com.palantir.javapoet.ArrayTypeName::withoutAnnotations()"
+      new: "method com.palantir.javapoet.ArrayTypeName com.palantir.javapoet.ArrayTypeName::withoutAnnotations()"
+      justification: "Refining return type of overridden method - javac will insert\
+        \ synthetic bridge methods"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method com.palantir.javapoet.TypeName com.palantir.javapoet.ParameterizedTypeName::withoutAnnotations()"
+      new: "method com.palantir.javapoet.ParameterizedTypeName com.palantir.javapoet.ParameterizedTypeName::withoutAnnotations()"
+      justification: "Refining return type of overridden method - javac will insert\
+        \ synthetic bridge methods"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method com.palantir.javapoet.TypeName com.palantir.javapoet.TypeVariableName::withoutAnnotations()"
+      new: "method com.palantir.javapoet.TypeVariableName com.palantir.javapoet.TypeVariableName::withoutAnnotations()"
+      justification: "Refining return type of overridden method - javac will insert\
+        \ synthetic bridge methods"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method com.palantir.javapoet.TypeName com.palantir.javapoet.WildcardTypeName::withoutAnnotations()"
+      new: "method com.palantir.javapoet.WildcardTypeName com.palantir.javapoet.WildcardTypeName::withoutAnnotations()"
+      justification: "Refining return type of overridden method - javac will insert\
+        \ synthetic bridge methods"

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
         classpath 'com.palantir.jakartapackagealignment:jakarta-package-alignment:0.6.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.90.0'
         classpath 'com.palantir.suppressible-error-prone:gradle-suppressible-error-prone:2.31.0'
+        classpath 'org.revapi:gradle-revapi:1.8.0'
     }
 }
 

--- a/javapoet/build.gradle
+++ b/javapoet/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.palantir.external-publish-jar'
+apply plugin: 'org.revapi.revapi-gradle-plugin'
 
 jar{
     manifest{

--- a/javapoet/src/main/java/com/palantir/javapoet/ArrayTypeName.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/ArrayTypeName.java
@@ -55,7 +55,7 @@ public final class ArrayTypeName extends TypeName {
     }
 
     @Override
-    public TypeName withoutAnnotations() {
+    public ArrayTypeName withoutAnnotations() {
         return new ArrayTypeName(componentType);
     }
 

--- a/javapoet/src/main/java/com/palantir/javapoet/ParameterizedTypeName.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/ParameterizedTypeName.java
@@ -69,7 +69,7 @@ public final class ParameterizedTypeName extends TypeName {
     }
 
     @Override
-    public TypeName withoutAnnotations() {
+    public ParameterizedTypeName withoutAnnotations() {
         return new ParameterizedTypeName(enclosingType, rawType.withoutAnnotations(), typeArguments);
     }
 

--- a/javapoet/src/main/java/com/palantir/javapoet/TypeVariableName.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/TypeVariableName.java
@@ -67,7 +67,7 @@ public final class TypeVariableName extends TypeName {
     }
 
     @Override
-    public TypeName withoutAnnotations() {
+    public TypeVariableName withoutAnnotations() {
         return new TypeVariableName(name, bounds);
     }
 

--- a/javapoet/src/main/java/com/palantir/javapoet/WildcardTypeName.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/WildcardTypeName.java
@@ -70,7 +70,7 @@ public final class WildcardTypeName extends TypeName {
     }
 
     @Override
-    public TypeName withoutAnnotations() {
+    public WildcardTypeName withoutAnnotations() {
         return new WildcardTypeName(upperBounds, lowerBounds);
     }
 


### PR DESCRIPTION
Fixes https://github.com/palantir/javapoet/issues/393

This PR also adds `revapi` to help ensure that we do not break the ABI.

This break detected in this change is a false positive - javac will insert synthetic bridge methods when covariantly refining the return type of an overridden method. For example, looking at the bytecode generated for `ParameterizedTypeName`, we can see this:

<img width="1369" height="396" alt="Screenshot 2026-04-02 at 10 12 04 PM" src="https://github.com/user-attachments/assets/5c150f4c-8f36-42b2-83f8-8c5da2b7b4f2" />
<img width="1064" height="252" alt="Screenshot 2026-04-02 at 10 12 31 PM" src="https://github.com/user-attachments/assets/23a9bca7-5150-46f5-af7c-19c4833f6888" />

I've also verified that this is not an ABI break in a local reproduction.