### PR TITLE
fix: Alignment of beginControlFlow without condition

### DIFF
--- a/javapoet/src/main/java/com/palantir/javapoet/CodeBlock.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/CodeBlock.java
@@ -412,7 +412,11 @@ public final class CodeBlock {
          * Shouldn't contain braces or newline characters.
          */
         public Builder beginControlFlow(String controlFlow, Object... args) {
-            add(controlFlow + " {\n", args);
+            if (controlFlow.isEmpty()) {
+                add("{\n", args);
+            } else {
+                add(controlFlow + " {\n", args);
+            }
             indent();
             return this;
         }

--- a/javapoet/src/test/java/com/palantir/javapoet/CodeBlockTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/CodeBlockTest.java
@@ -65,6 +65,17 @@ public final class CodeBlockTest {
     }
 
     @Test
+    public void alignedEmptyControlFlow() {
+        assertThat(CodeBlock.builder()
+                        .add("// Aligned\n")
+                        .beginControlFlow("")
+                        .endControlFlow()
+                        .build()
+                        .toString())
+                .contains("\n{");
+    }
+
+    @Test
     public void dollarSignEscapeCannotBeIndexed() {
         assertThatThrownBy(() -> CodeBlock.builder().add("$1$", "taco").build())
                 .isInstanceOf(IllegalArgumentException.class)


### PR DESCRIPTION


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Previously code like


    codeBlock
        .add("// This is the baseline alignment\n")
        .beginControlFlow("")
        .endControlFlow()

would generate:

    // This is the baseline alignment
     {
    }

## After this PR



After this commit, this will be aligned properly:


    // This is the baseline alignment
    {
    }

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
fix: Properly align empty .beginControlFlow("") instructions
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

It is very unlikely that a user would be negatively affected by the missing space. A possible alternative would be an additional method. This specific patch however also works with `MethodSpec`, which delegates to the interior (and private) `CodeBlock`.