### PR TITLE
Fix nested annotation arrays

### DIFF
--- a/javapoet/src/main/java/com/palantir/javapoet/AnnotationSpec.java
+++ b/javapoet/src/main/java/com/palantir/javapoet/AnnotationSpec.java
@@ -144,10 +144,6 @@ public final class AnnotationSpec {
                     }
                     continue;
                 }
-                if (value instanceof Annotation annotationValue) {
-                    builder.addMember(method.getName(), "$L", get(annotationValue));
-                    continue;
-                }
                 builder.addMemberForValue(method.getName(), value);
             }
         } catch (Exception e) {
@@ -244,6 +240,9 @@ public final class AnnotationSpec {
             checkNotNull(memberName, "memberName == null");
             checkNotNull(value, "value == null, constant non-null value expected for %s", memberName);
             checkArgument(SourceVersion.isName(memberName), "not a valid name: %s", memberName);
+            if (value instanceof Annotation annotationValue) {
+                return addMember(memberName, "$L", get(annotationValue));
+            }
             if (value instanceof Class<?>) {
                 return addMember(memberName, "$T.class", value);
             }

--- a/javapoet/src/test/java/com/palantir/javapoet/AnnotationSpecTest.java
+++ b/javapoet/src/test/java/com/palantir/javapoet/AnnotationSpecTest.java
@@ -42,6 +42,11 @@ public final class AnnotationSpecTest {
         String value();
     }
 
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface HasAnnotationArray {
+        AnnotationC[] value();
+    }
+
     public enum Breakfast {
         WAFFLES,
         PANCAKES;
@@ -103,6 +108,10 @@ public final class AnnotationSpecTest {
             r = {Float.class, Double.class})
     public class IsAnnotated {
         // empty
+    }
+
+    @HasAnnotationArray({@AnnotationC("foo"), @AnnotationC("bar")})
+    public class IsAnnotatedWithArray {
     }
 
     @Rule
@@ -301,6 +310,25 @@ public final class AnnotationSpecTest {
                     Double.class
                 }
             )
+            class Taco {
+            }
+            """);
+    }
+
+    @Test
+    public void reflectAnnotationArray() {
+        HasAnnotationArray annotation = IsAnnotatedWithArray.class.getAnnotation(HasAnnotationArray.class);
+        AnnotationSpec spec = AnnotationSpec.get(annotation);
+        TypeSpec taco = TypeSpec.classBuilder("Taco").addAnnotation(spec).build();
+        assertThat(toString(taco)).isEqualTo("""
+            package com.palantir.tacos;
+
+            import com.palantir.javapoet.AnnotationSpecTest;
+
+            @AnnotationSpecTest.HasAnnotationArray({
+                @AnnotationSpecTest.AnnotationC("foo"),
+                @AnnotationSpecTest.AnnotationC("bar")
+            })
             class Taco {
             }
             """);


### PR DESCRIPTION
## Before this PR

`AnnotationSpec.get(Annotation)` relied on `toString()` for nested annotation array values, producing invalid source.

## After this PR

Nested annotation arrays are emitted recursively as annotation literals.

==COMMIT_MSG==
Fix nested annotation arrays
==COMMIT_MSG==

Fixes #446

Tests: `.\gradlew.bat test` (395 tests)

## Possible downsides?

None known.